### PR TITLE
Feature/댓글 조회 기능 수정

### DIFF
--- a/src/docs/asciidoc/admin.adoc
+++ b/src/docs/asciidoc/admin.adoc
@@ -45,7 +45,7 @@ link:postingAdmin.html[API 문서 보기]
 
 == *댓글*
 
-link:commentAdmin.html[API 문서 보기]
+link:posting/commentAdmin.html[API 문서 보기]
 
 == *회원 관리*
 

--- a/src/docs/asciidoc/keeper.adoc
+++ b/src/docs/asciidoc/keeper.adoc
@@ -53,7 +53,7 @@ link:posting.html[API 문서 보기]
 
 == *댓글*
 
-link:comment.html[API 문서 보기]
+link:posting/comment.html[API 문서 보기]
 
 == *회원 관리*
 

--- a/src/docs/asciidoc/posting/comment.adoc
+++ b/src/docs/asciidoc/posting/comment.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 == API 목록
 
-link:keeper.html[API 목록으로 돌아가기]
+link:../keeper.html[API 목록으로 돌아가기]
 
 == *댓글 생성*
 

--- a/src/docs/asciidoc/posting/commentAdmin.adoc
+++ b/src/docs/asciidoc/posting/commentAdmin.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 == API 목록
 
-link:admin.html[API 목록으로 돌아가기]
+link:../admin.html[API 목록으로 돌아가기]
 
 == *댓글 삭제*
 

--- a/src/main/java/keeper/project/homepage/repository/posting/CommentRepository.java
+++ b/src/main/java/keeper/project/homepage/repository/posting/CommentRepository.java
@@ -1,18 +1,19 @@
 package keeper.project.homepage.repository.posting;
 
+import java.util.List;
 import keeper.project.homepage.entity.posting.CommentEntity;
 import keeper.project.homepage.entity.posting.PostingEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
-  Page<CommentEntity> findAllByPostingId(PostingEntity postingEntity, Pageable pageable);
+  List<CommentEntity> findAll(Specification<CommentEntity> spec);
 
-  Page<CommentEntity> findAllByParentIdAndPostingId(Long parentId, PostingEntity postingEntity,
-      Pageable pageable);
+  List<CommentEntity> findAll(Specification<CommentEntity> spec, Pageable pageable);
 
 }

--- a/src/main/java/keeper/project/homepage/repository/posting/CommentSpec.java
+++ b/src/main/java/keeper/project/homepage/repository/posting/CommentSpec.java
@@ -1,0 +1,32 @@
+package keeper.project.homepage.repository.posting;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import keeper.project.homepage.entity.posting.CommentEntity;
+import keeper.project.homepage.entity.posting.PostingEntity;
+import org.springframework.data.jpa.domain.Specification;
+
+public class CommentSpec {
+
+  public static Specification<CommentEntity> equalParentId(final Long id) {
+    return new Specification<CommentEntity>() {
+      @Override
+      public Predicate toPredicate(Root<CommentEntity> root, CriteriaQuery<?> query,
+          CriteriaBuilder criteriaBuilder) {
+        return criteriaBuilder.equal(root.get("parentId"), id);
+      }
+    };
+  }
+
+  public static Specification<CommentEntity> equalPosting(final PostingEntity posting) {
+    return new Specification<CommentEntity>() {
+      @Override
+      public Predicate toPredicate(Root<CommentEntity> root, CriteriaQuery<?> query,
+          CriteriaBuilder criteriaBuilder) {
+        return criteriaBuilder.equal(root.get("postingId"), posting);
+      }
+    };
+  }
+}

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -1,0 +1,167 @@
+package keeper.project.homepage;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import keeper.project.homepage.ApiControllerTestSetUp;
+import keeper.project.homepage.dto.result.SingleResult;
+import keeper.project.homepage.dto.sign.SignInDto;
+import keeper.project.homepage.entity.member.MemberEntity;
+import keeper.project.homepage.entity.member.MemberHasMemberJobEntity;
+import keeper.project.homepage.entity.member.MemberJobEntity;
+import keeper.project.homepage.entity.posting.CategoryEntity;
+import keeper.project.homepage.entity.posting.CommentEntity;
+import keeper.project.homepage.entity.posting.PostingEntity;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MvcResult;
+
+public class ApiControllerTestHelper extends ApiControllerTestSetUp {
+
+  final public String memberPassword = "memberPassword";
+  final public String postingPassword = "postingPassword";
+
+  public enum MemberJobName {
+    회장("ROLE_회장"),
+    부회장("ROLE_부회장"),
+    대외부장("ROLE_대외부장"),
+    학술부장("ROLE_학술부장"),
+    전산관리자("ROLE_전산관리자"),
+    서기("ROLE_서기"),
+    총무("ROLE_총무"),
+    사서("ROLE_사서"),
+    회원("ROLE_회원");
+
+    private String jobName;
+
+    MemberJobName(String jobName) {
+      this.jobName = jobName;
+    }
+
+    public String getJobName() {
+      return jobName;
+    }
+  }
+
+  public enum ResponseType {
+    SINGLE("data"),
+    LIST("list[]");
+
+    private final String reponseFieldPrefix;
+
+    ResponseType(String reponseFieldPrefix) {
+      this.reponseFieldPrefix = reponseFieldPrefix;
+    }
+
+    public String getReponseFieldPrefix() {
+      return reponseFieldPrefix;
+    }
+  }
+
+  public MemberEntity generateMemberEntity(MemberJobName jobName) {
+    final String epochTime = Long.toHexString(System.nanoTime());
+    MemberJobEntity memberJobEntity = memberJobRepository.findByName(jobName.getJobName()).get();
+    MemberHasMemberJobEntity hasMemberJobEntity = MemberHasMemberJobEntity.builder()
+        .memberJobEntity(memberJobEntity)
+        .build();
+    return memberRepository.saveAndFlush(MemberEntity.builder()
+        .loginId("LoginId" + epochTime)
+        .password(passwordEncoder.encode(memberPassword))
+        .realName("RealName")
+        .nickName("NickName")
+        .emailAddress("member" + epochTime + "@k33p3r.com")
+        .studentId(epochTime)
+        .memberJobs(new ArrayList<>(List.of(hasMemberJobEntity)))
+        .build());
+  }
+
+  public String generateJWTToken(String loginId, String password) throws Exception {
+    String content = "{\n"
+        + "    \"loginId\": \"" + loginId + "\",\n"
+        + "    \"password\": \"" + password + "\"\n"
+        + "}";
+    MvcResult result = mockMvc.perform(post("/v1/signin")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(content))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.code").value(0))
+        .andExpect(jsonPath("$.msg").exists())
+        .andExpect(jsonPath("$.data").exists())
+        .andReturn();
+
+    String resultString = result.getResponse().getContentAsString();
+    ObjectMapper mapper = new ObjectMapper();
+    SingleResult<SignInDto> sign = mapper.readValue(resultString, new TypeReference<>() {
+    });
+    return sign.getData().getToken();
+  }
+
+  public CategoryEntity generateCategoryEntity() {
+    final String epochTime = Long.toHexString(System.nanoTime());
+    return categoryRepository.save(
+        CategoryEntity.builder().name("testCategory" + epochTime).build());
+  }
+
+  public PostingEntity generatePostingEntity(MemberEntity writer, CategoryEntity category,
+      Integer isNotice, Integer isSecret, Integer isTemp) {
+    final String epochTime = Long.toHexString(System.nanoTime());
+    final LocalDateTime now = LocalDateTime.now();
+    return postingRepository.save(PostingEntity.builder()
+        .title("posting 제목 " + epochTime)
+        .content("posting 내용 " + epochTime)
+        .categoryId(category)
+        .ipAddress("192.111.222.333")
+        .allowComment(0)
+        .isNotice(isNotice)
+        .isSecret(isSecret)
+        .isTemp(isTemp)
+        .likeCount(0)
+        .dislikeCount(0)
+        .commentCount(0)
+        .visitCount(0)
+        .registerTime(now)
+        .updateTime(now)
+        .password(postingPassword)
+        .memberId(writer)
+        .build());
+  }
+
+  public CommentEntity generateCommentEntity(PostingEntity posting, MemberEntity writer,
+      Long parentId) {
+    final String epochTime = Long.toHexString(System.nanoTime());
+    final LocalDateTime now = LocalDateTime.now();
+    final String content = (parentId == 0L ? "댓글 내용 " : parentId + "의 대댓글 내용 ") + epochTime;
+    return commentRepository.save(CommentEntity.builder()
+        .content(content)
+        .registerTime(now)
+        .updateTime(now)
+        .ipAddress("111.111.111.111")
+        .likeCount(0)
+        .dislikeCount(0)
+        .parentId(parentId)
+        .member(writer)
+        .postingId(posting)
+        .build());
+  }
+  
+  public List<FieldDescriptor> generateCommonResponseFields(String docSuccess, String docCode,
+      String docMsg) {
+    List<FieldDescriptor> commonFields = new ArrayList<>();
+    commonFields.addAll(Arrays.asList(
+        fieldWithPath("success").description(docSuccess),
+        fieldWithPath("code").description(docCode),
+        fieldWithPath("msg").description(docMsg)));
+    return commonFields;
+  }
+}

--- a/src/test/java/keeper/project/homepage/controller/posting/CommentControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/CommentControllerTest.java
@@ -13,23 +13,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Arrays;
 import java.util.List;
-import keeper.project.homepage.ApiControllerTestSetUp;
-import keeper.project.homepage.dto.result.SingleResult;
-import keeper.project.homepage.dto.sign.SignInDto;
-import keeper.project.homepage.entity.member.MemberHasMemberJobEntity;
-import keeper.project.homepage.entity.member.MemberJobEntity;
+import keeper.project.homepage.ApiControllerTestHelper;
 import keeper.project.homepage.entity.posting.CategoryEntity;
 import keeper.project.homepage.entity.posting.CommentEntity;
 import keeper.project.homepage.entity.posting.PostingEntity;
 import keeper.project.homepage.entity.member.MemberEntity;
-import keeper.project.homepage.service.util.AuthService;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,172 +28,75 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @Log4j2
-public class CommentControllerTest extends ApiControllerTestSetUp {
-
-  final private String adminLoginId = "hyeonmoAdmin";
-  final private String adminPassword = "keeper2";
-  final private String adminRealName = "JeongHyeonMo2";
-  final private String adminNickName = "JeongHyeonMo2";
-  final private String adminEmailAddress = "test2@k33p3r.com";
-  final private String adminStudentId = "201724580";
-
-  final private String loginId = "hyeonmomo";
-  final private String password = "keeper";
-  final private String realName = "JeongHyeonMo";
-  final private String nickName = "JeongHyeonMo";
-  final private String emailAddress = "gusah@naver.com";
-  final private String studentId = "201724579";
-
-  private LocalDateTime registerTime = LocalDateTime.now();
-  private LocalDateTime updateTime = LocalDateTime.now();
-  private String ipAddress = "127.0.0.1";
-  private Integer likeCount = 0;
-  private Integer dislikeCount = 0;
+public class CommentControllerTest extends ApiControllerTestHelper {
 
   private PostingEntity postingEntity;
-  private CommentEntity parentComment;
   private CommentEntity commentEntity;
-  private MemberEntity memberEntity;
+  private CommentEntity replyEntity;
+  private MemberEntity userEntity;
   private MemberEntity adminEntity;
-  private AuthService authService;
 
   private String userToken;
   private String adminToken;
+  
+  public List<FieldDescriptor> generateCommonCommentResponse(ResponseType type, String docSuccess,
+      String docCode, String docMsg, FieldDescriptor... descriptors) {
+    String prefix = type.getReponseFieldPrefix();
+    List<FieldDescriptor> commonFields = new ArrayList<>();
+    commonFields.addAll(generateCommonResponseFields(docSuccess, docCode, docMsg));
+    commonFields.addAll(Arrays.asList(
+        fieldWithPath(prefix + ".id").description("댓글 id"),
+        fieldWithPath(prefix + ".content").description("댓글 내용"),
+        fieldWithPath(prefix + ".registerTime").description("댓글이 처음 등록된 시간"),
+        fieldWithPath(prefix + ".updateTime").description("댓글이 수정된 시간"),
+        fieldWithPath(prefix + ".ipAddress").description("댓글 작성자의 ip address"),
+        fieldWithPath(prefix + ".likeCount").description("좋아요 개수"),
+        fieldWithPath(prefix + ".dislikeCount").description("싫어요 개수"),
+        fieldWithPath(prefix + ".parentId").description("대댓글인 경우, 부모 댓글의 id"),
+        fieldWithPath(prefix + ".writer").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
+        fieldWithPath(prefix + ".writerId").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
+        fieldWithPath(prefix + ".writerThumbnailId").optional().type(Long.TYPE)
+            .description("작성자 (탈퇴했을 경우 / 썸네일을 등록하지 않았을 경우 null)")));
+    if (descriptors.length > 0) {
+      commonFields.addAll(Arrays.asList(descriptors));
+    }
+    return commonFields;
+  }
 
   @BeforeEach
   public void setUp() throws Exception {
-    MemberJobEntity memberJobEntity = memberJobRepository.findByName("ROLE_회원").get();
-    MemberJobEntity adminJobEntity = memberJobRepository.findByName("ROLE_회장").get();
-    MemberHasMemberJobEntity hasMemberJobEntity = MemberHasMemberJobEntity.builder()
-        .memberJobEntity(memberJobEntity)
-        .build();
-    MemberHasMemberJobEntity adminHasMemberJobEntity = MemberHasMemberJobEntity.builder()
-        .memberJobEntity(adminJobEntity)
-        .build();
-    memberEntity = memberRepository.save(MemberEntity.builder()
-        .loginId(loginId)
-        .password(passwordEncoder.encode(password))
-        .realName(realName)
-        .nickName(nickName)
-        .emailAddress(emailAddress)
-        .studentId(studentId)
-        .memberJobs(new ArrayList<>(List.of(hasMemberJobEntity)))
-        .build());
-    String content = "{\n"
-        + "    \"loginId\": \"" + loginId + "\",\n"
-        + "    \"password\": \"" + password + "\"\n"
-        + "}";
-    MvcResult result = mockMvc.perform(post("/v1/signin")
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content(content))
-        .andDo(print())
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.code").value(0))
-        .andExpect(jsonPath("$.msg").exists())
-        .andExpect(jsonPath("$.data").exists())
-        .andReturn();
+    userEntity = generateMemberEntity(MemberJobName.회원);
+    userToken = generateJWTToken(userEntity.getLoginId(), memberPassword);
+    adminEntity = generateMemberEntity(MemberJobName.회장);
+    adminToken = generateJWTToken(adminEntity.getLoginId(), memberPassword);
 
-    String resultString = result.getResponse().getContentAsString();
-    ObjectMapper mapper = new ObjectMapper();
-    SingleResult<SignInDto> sign = mapper.readValue(resultString, new TypeReference<>() {
-    });
-    userToken = sign.getData().getToken();
-
-    adminEntity = memberRepository.save(MemberEntity.builder()
-        .loginId(adminLoginId)
-        .password(passwordEncoder.encode(adminPassword))
-        .realName(adminRealName)
-        .nickName(adminNickName)
-        .emailAddress(adminEmailAddress)
-        .studentId(adminStudentId)
-        .memberJobs(new ArrayList<>(List.of(adminHasMemberJobEntity)))
-        .build());
-    String adminContent = "{\n"
-        + "    \"loginId\": \"" + adminLoginId + "\",\n"
-        + "    \"password\": \"" + adminPassword + "\"\n"
-        + "}";
-    MvcResult adminResult = mockMvc.perform(post("/v1/signin")
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .content(adminContent))
-        .andDo(print())
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.code").value(0))
-        .andExpect(jsonPath("$.msg").exists())
-        .andExpect(jsonPath("$.data").exists())
-        .andReturn();
-
-    String adminResultString = adminResult.getResponse().getContentAsString();
-    SingleResult<SignInDto> adminSign = mapper.readValue(adminResultString, new TypeReference<>() {
-    });
-    adminToken = adminSign.getData().getToken();
-
-    CategoryEntity categoryEntity = categoryRepository.save(
-        CategoryEntity.builder().name("test category").build());
-
-    postingEntity = postingRepository.save(PostingEntity.builder()
-        .title("posting 제목")
-        .content("posting 내용")
-        .categoryId(categoryEntity)
-        .ipAddress("192.111.222.333")
-        .allowComment(0)
-        .isNotice(0)
-        .isSecret(1)
-        .isTemp(0)
-        .likeCount(10)
-        .dislikeCount(1)
-        .commentCount(0)
-        .visitCount(0)
-        .registerTime(LocalDateTime.now())
-        .updateTime(LocalDateTime.now())
-        .password("asdsdf")
-        .memberId(memberEntity)
-        .build());
-
-    parentComment = commentRepository.save(CommentEntity.builder()
-        .content("부모 댓글 내용")
-        .registerTime(registerTime)
-        .updateTime(updateTime)
-        .ipAddress(ipAddress)
-        .likeCount(likeCount)
-        .dislikeCount(dislikeCount)
-        .parentId(0L)
-        .member(memberEntity)
-        .postingId(postingEntity)
-        .build());
-
-    commentEntity = commentRepository.save(CommentEntity.builder()
-        .content("댓글 내용")
-        .registerTime(registerTime)
-        .updateTime(updateTime)
-        .ipAddress(ipAddress)
-        .likeCount(likeCount)
-        .dislikeCount(dislikeCount)
-        .parentId(parentComment.getId())
-        .member(memberEntity)
-        .postingId(postingEntity)
-        .build());
-
+    CategoryEntity categoryEntity = generateCategoryEntity();
+    postingEntity = generatePostingEntity(userEntity, categoryEntity, 0, 1, 0);
+    commentEntity = generateCommentEntity(postingEntity, userEntity, 0L);
+    replyEntity = generateCommentEntity(postingEntity, userEntity, commentEntity.getId());
   }
 
   @Test
   @DisplayName("댓글 생성")
   public void commentCreateTest() throws Exception {
-    Long commentParentId = parentComment.getId();
     Long postId = postingEntity.getId();
     String content = "{\n"
         + "    \"content\": \"SDFASFASG\",\n"
         + "    \"ipAddress\": \"672.523.937.636\",\n"
-        + "    \"parentId\": \n" + commentParentId + "\n"
+        + "    \"parentId\": \n" + 0L + "\n"
         + "}";
 
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode =
+        "댓글의 내용이 비어있는 경우: " + exceptionAdvice.getMessage("commentEmptyField.code") + " +\n"
+            + "그 외 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "댓글 내용이 비어있는 경우 실패합니다.";
     mockMvc.perform(post("/v1/comment/{postId}", postId)
             .header("Authorization", userToken)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -222,16 +116,14 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                     .description("모댓글: 입력 없음(db에는 0으로 설정), 대댓글: 부모 댓글의 id")
             ),
             responseFields(
-                fieldWithPath("success").description("성공: true +\n실패: false"),
-                fieldWithPath("code").description("content가 비어있을 경우: BAD_REQUEST(400)"),
-                fieldWithPath("msg").description("content가 비어있을 경우: \"댓글의 내용이 비어있습니다.\"")
+                generateCommonResponseFields(docSuccess, docCode, docMsg)
             )));
   }
 
   @Test
   @DisplayName("댓글 생성 실패 - content가 비어있는 경우")
   public void commentCreateFailTest() throws Exception {
-    Long commentParentId = parentComment.getId();
+    Long commentParentId = commentEntity.getId();
     Long postId = postingEntity.getId();
     String content = "{\n"
         + "    \"content\": \"\",\n"
@@ -253,22 +145,21 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
   @Test
   @DisplayName("댓글 페이징")
   public void showCommentByPostIdTest() throws Exception {
-    Long postId = postingEntity.getId();
-    for (int i = 0; i < 15; i++) {
-      CommentEntity comment = commentRepository.save(CommentEntity.builder()
-          .content("페이징 댓글 내용 " + i)
-          .registerTime(registerTime)
-          .updateTime(updateTime)
-          .ipAddress(ipAddress)
-          .likeCount(likeCount)
-          .dislikeCount(dislikeCount)
-          .parentId(commentEntity.getId())
-          .member(memberEntity)
-          .postingId(postingEntity)
-          .build());
-      commentService.updateLikeCount(memberEntity.getId(), comment.getId());
+    CommentEntity anotherComment = generateCommentEntity(postingEntity, userEntity, 0L);
+    Long commentId = anotherComment.getId();
+    for (int i = 0; i < 5; i++) {
+      generateCommentEntity(postingEntity, userEntity, commentId);
     }
 
+    commentId = commentEntity.getId();
+    for (int i = 0; i < 7; i++) {
+      generateCommentEntity(postingEntity, userEntity, commentId);
+    }
+
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode = "에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "페이지 당 댓글의 개수는 최대 10개, 댓글에 달린 대댓글의 개수는 제한 없이 조회됩니다.";
+    Long postId = postingEntity.getId();
     mockMvc.perform(
             RestDocumentationRequestBuilders.get("/v1/comment/{postId}", postId)
                 .param("page", "0")
@@ -277,7 +168,6 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
         )
         .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.[?(@.list.length() == 10)]").exists()) // 0페이지의 댓글 수 10개인지 확인
         .andDo(document("comment-list",
             pathParameters(
                 parameterWithName("postId").description("조회할 댓글들이 포함된 게시글의 id")
@@ -287,25 +177,11 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                 parameterWithName("size").description("한 페이지에 들어갈 댓글 개수 (default : 10)")
             ),
             responseFields(
-                fieldWithPath("success").description("true").ignored(),
-                fieldWithPath("code").description("0").ignored(),
-                fieldWithPath("msg").description("성공하였습니다").ignored(),
-                fieldWithPath("list[].id").description("댓글 id"),
-                fieldWithPath("list[].content").description("댓글 내용"),
-                fieldWithPath("list[].registerTime").description("댓글이 처음 등록된 시간"),
-                fieldWithPath("list[].updateTime").description("댓글이 수정된 시간"),
-                fieldWithPath("list[].ipAddress").description("댓글 작성자의 ip address"),
-                fieldWithPath("list[].likeCount").description("좋아요 개수"),
-                fieldWithPath("list[].dislikeCount").description("싫어요 개수"),
-                fieldWithPath("list[].checkedLike").description(
-                    "좋아요 눌렀는지 확인 (눌렀으면 true, 아니면 false)"),
-                fieldWithPath("list[].checkedDislike").description(
-                    "싫어요 눌렀는지 확인 (눌렀으면 true, 아니면 false)"),
-                fieldWithPath("list[].parentId").description("대댓글인 경우, 부모 댓글의 id"),
-                fieldWithPath("list[].writer").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
-                fieldWithPath("list[].writerId").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
-                fieldWithPath("list[].writerThumbnailId").optional().type(Long.TYPE)
-                    .description("작성자 (탈퇴했을 경우 / 썸네일을 등록하지 않았을 경우 null)")
+                generateCommonCommentResponse(ResponseType.LIST, docSuccess, docCode, docMsg,
+                    fieldWithPath("list[].checkedLike").description(
+                        "좋아요 눌렀는지 확인 (눌렀으면 true, 아니면 false)"),
+                    fieldWithPath("list[].checkedDislike").description(
+                        "싫어요 눌렀는지 확인 (눌렀으면 true, 아니면 false)"))
             )
         ));
   }
@@ -313,7 +189,12 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
   @Test
   @DisplayName("댓글 삭제 - 성공")
   public void commentDeleteTest() throws Exception {
-    Long commentId = commentEntity.getId();
+    Long commentId = replyEntity.getId();
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode =
+        "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
+            + "삭제 중 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "댓글 기록을 완전히 삭제하지 않고 작성자와 댓글 내용, 좋아요와 싫어요 수를 초기화합니다.";
     mockMvc.perform(RestDocumentationRequestBuilders.delete("/v1/comment/{commentId}", commentId)
             .header("Authorization", userToken))
         .andExpect(status().isOk())
@@ -323,12 +204,7 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                 parameterWithName("commentId").description("삭제할 댓글의 id")
             ),
             responseFields(
-                fieldWithPath("success").description("성공: true +\n실패: false"),
-                fieldWithPath("code").description(
-                    "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
-                        + "삭제 중 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code")),
-                fieldWithPath("msg").description(
-                    "댓글 기록을 완전히 삭제하지 않고 작성자와 댓글 내용, 좋아요와 싫어요 수를 초기화합니다.")
+                generateCommonResponseFields(docSuccess, docCode, docMsg)
             )
         ));
   }
@@ -336,7 +212,12 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
   @Test
   @DisplayName("관리자 권한 댓글 삭제 - 성공")
   public void adminCommentDeleteTest() throws Exception {
-    Long commentId = commentEntity.getId();
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode =
+        "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
+            + "삭제 중 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "댓글 기록을 완전히 삭제하지 않고 작성자와 댓글 내용, 좋아요와 싫어요 수를 초기화합니다.";
+    Long commentId = replyEntity.getId();
     mockMvc.perform(
             RestDocumentationRequestBuilders.delete("/v1/admin/comment/{commentId}", commentId)
                 .header("Authorization", adminToken))
@@ -347,12 +228,7 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                 parameterWithName("commentId").description("삭제할 댓글의 id")
             ),
             responseFields(
-                fieldWithPath("success").description("성공: true +\n실패: false"),
-                fieldWithPath("code").description(
-                    "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
-                        + "삭제 중 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code")),
-                fieldWithPath("msg").description(
-                    "댓글 기록을 완전히 삭제하지 않고 작성자와 댓글 내용, 좋아요와 싫어요 수를 초기화합니다.")
+                generateCommonResponseFields(docSuccess, docCode, docMsg)
             )
         ));
   }
@@ -360,9 +236,16 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
   @Test
   @DisplayName("댓글 수정")
   public void commentUpdateTest() throws Exception {
-    Long updateId = commentEntity.getId();
+    Long updateId = replyEntity.getId();
     String updateString = "수정한 내용!";
     String updateContent = String.format("{\"content\": \"%s\"}", updateString);
+
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode =
+        "수정할 내용이 비어있는 경우: " + exceptionAdvice.getMessage("commentEmptyField.code") + " +\n"
+            + "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
+            + "그 외 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "수정할 내용이 비어있거나, 수정할 댓글이 존재하지 않는 경우 실패합니다.";
     mockMvc.perform(put("/v1/comment/{commentId}", updateId)
             .header("Authorization", userToken)
             .content(updateContent)
@@ -378,31 +261,14 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("content").description("수정할 댓글 내용")
             ),
             responseFields(
-                fieldWithPath("success").description("성공: true +\n실패: false"),
-                fieldWithPath("code").description("commentId가 존재하지 않는 경우: BAD_REQUEST(400)" + " +\n"
-                    + "content가 비어있을 경우: BAD_REQUEST(400)"),
-                fieldWithPath("msg").description("content가 비어있을 경우: \"댓글의 내용이 비어있습니다.\""),
-                fieldWithPath("data.id").description("수정한 댓글 id"),
-                fieldWithPath("data.content").description("수정한 댓글 내용"),
-                fieldWithPath("data.registerTime").ignored(),
-                fieldWithPath("data.updateTime").description("수정한 시간"),
-                fieldWithPath("data.ipAddress").description("수정한 댓글 작성자의 ipAddress"),
-                fieldWithPath("data.likeCount").ignored(),
-                fieldWithPath("data.dislikeCount").ignored(),
-                fieldWithPath("data.parentId").ignored(),
-                fieldWithPath("data.writer").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
-                fieldWithPath("data.writerId").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
-                fieldWithPath("data.writerThumbnailId").optional().type(Long.TYPE)
-                    .description("작성자 (탈퇴했을 경우 / 썸네일을 등록하지 않았을 경우 null)")
-//                fieldWithPath("data.memberId").ignored(),
-//                fieldWithPath("data.postingId").ignored()
+                generateCommonCommentResponse(ResponseType.SINGLE, docSuccess, docCode, docMsg)
             )));
   }
 
   @Test
   @DisplayName("댓글 수정 실패 - content가 비어있는 경우")
   public void commentUpdateFailTest() throws Exception {
-    Long updateId = commentEntity.getId();
+    Long updateId = replyEntity.getId();
     String updateContent = "{\"content\": \"\"}";
     mockMvc.perform(put("/v1/comment/{commentId}", updateId)
             .header("Authorization", userToken)
@@ -416,13 +282,19 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
   @Test
   @DisplayName("댓글 좋아요 추가 및 취소")
   public void updateLikeTest() throws Exception {
-    Long commentId = commentEntity.getId();
-    Integer befLikeCount = commentEntity.getLikeCount();
+    Long commentId = replyEntity.getId();
+    Integer befLikeCount = replyEntity.getLikeCount();
+
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode =
+        "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
+            + "그 외 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "댓글이 존재하지 않는 경우 실패합니다.";
     // 좋아요 추가
     mockMvc.perform(RestDocumentationRequestBuilders.get("/v1/comment/like")
             .header("Authorization", userToken)
-            .param("commentId", commentEntity.getId().toString())
-            .param("memberId", memberEntity.getId().toString()))
+            .param("commentId", replyEntity.getId().toString())
+            .param("memberId", userEntity.getId().toString()))
         .andDo(print())
         .andExpect(status().isOk())
         .andDo(document("comment-like",
@@ -431,36 +303,40 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                 parameterWithName("memberId").description("좋아요 추가 또는 취소를 수행하는 멤버의 id")
             ),
             responseFields(
-                fieldWithPath("success").description("성공: true"),
-                fieldWithPath("code").description("").ignored(),
-                fieldWithPath("msg").description("").ignored()
+                generateCommonResponseFields(docSuccess, docCode, docMsg)
             )));
     Integer addLikeCount = commentRepository.findById(commentId).get().getLikeCount();
-    Assertions.assertNotNull(memberHasCommentLikeService.findById(memberEntity, commentEntity));
+    Assertions.assertNotNull(memberHasCommentLikeService.findById(userEntity, replyEntity));
     Assertions.assertEquals(befLikeCount + 1, addLikeCount);
 
     // 좋아요 취소
     mockMvc.perform(RestDocumentationRequestBuilders.get("/v1/comment/like")
             .header("Authorization", userToken)
-            .param("commentId", commentEntity.getId().toString())
-            .param("memberId", memberEntity.getId().toString()))
+            .param("commentId", replyEntity.getId().toString())
+            .param("memberId", userEntity.getId().toString()))
         .andDo(print())
         .andExpect(status().isOk());
     Integer delLikeCount = commentRepository.findById(commentId).get().getLikeCount();
-    Assertions.assertNull(memberHasCommentLikeService.findById(memberEntity, commentEntity));
+    Assertions.assertNull(memberHasCommentLikeService.findById(userEntity, replyEntity));
     Assertions.assertEquals(addLikeCount - 1, delLikeCount);
   }
 
   @Test
   @DisplayName("댓글 싫어요 추가 및 취소")
   public void updateDislikeTest() throws Exception {
-    Long commentId = commentEntity.getId();
-    Integer befDislikeCount = commentEntity.getDislikeCount();
+    Long commentId = replyEntity.getId();
+    Integer befDislikeCount = replyEntity.getDislikeCount();
+
+    String docSuccess = "성공: true +\n실패: false";
+    String docCode =
+        "존재하지 않는 댓글인 경우: " + exceptionAdvice.getMessage("commentNotFound.code") + " +\n"
+            + "그 외 에러가 난 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    String docMsg = "댓글이 존재하지 않는 경우 실패합니다.";
     // 싫어요 추가
     mockMvc.perform(RestDocumentationRequestBuilders.get("/v1/comment/dislike")
             .header("Authorization", userToken)
-            .param("commentId", commentEntity.getId().toString())
-            .param("memberId", memberEntity.getId().toString()))
+            .param("commentId", replyEntity.getId().toString())
+            .param("memberId", userEntity.getId().toString()))
         .andDo(print())
         .andExpect(status().isOk())
         .andDo(document("comment-dislike",
@@ -469,23 +345,21 @@ public class CommentControllerTest extends ApiControllerTestSetUp {
                 parameterWithName("memberId").description("싫어요 추가 또는 취소를 수행하는 멤버의 id")
             ),
             responseFields(
-                fieldWithPath("success").description("성공: true"),
-                fieldWithPath("code").description("").ignored(),
-                fieldWithPath("msg").description("").ignored()
+                generateCommonResponseFields(docSuccess, docCode, docMsg)
             )));
     Integer addDislikeCount = commentRepository.findById(commentId).get().getDislikeCount();
-    Assertions.assertNotNull(memberHasCommentDislikeService.findById(memberEntity, commentEntity));
+    Assertions.assertNotNull(memberHasCommentDislikeService.findById(userEntity, replyEntity));
     Assertions.assertEquals(befDislikeCount + 1, addDislikeCount);
 
     // 싫어요 취소
     mockMvc.perform(RestDocumentationRequestBuilders.get("/v1/comment/dislike")
             .header("Authorization", userToken)
-            .param("commentId", commentEntity.getId().toString())
-            .param("memberId", memberEntity.getId().toString()))
+            .param("commentId", replyEntity.getId().toString())
+            .param("memberId", userEntity.getId().toString()))
         .andDo(print())
         .andExpect(status().isOk());
     Integer delDislikeCount = commentRepository.findById(commentId).get().getDislikeCount();
-    Assertions.assertNull(memberHasCommentDislikeService.findById(memberEntity, commentEntity));
+    Assertions.assertNull(memberHasCommentDislikeService.findById(userEntity, replyEntity));
     Assertions.assertEquals(addDislikeCount - 1, delDislikeCount);
   }
 }


### PR DESCRIPTION
- 댓글 조회 시 댓글, 대댓글 정렬
  - 한 페이지 당 댓글은 최대 10개, 댓글에 달린 대댓글은 페이지 사이즈 상관없이 모두 조회
- 댓글 api docs 문구 수정