### PR TITLE
Feature/게임 획득 포인트 추가

### DIFF
--- a/src/main/java/keeper/project/homepage/controller/attendance/GameController.java
+++ b/src/main/java/keeper/project/homepage/controller/attendance/GameController.java
@@ -1,6 +1,7 @@
 package keeper.project.homepage.controller.attendance;
 
 import java.util.HashMap;
+import keeper.project.homepage.dto.attendance.LottoDto;
 import keeper.project.homepage.dto.attendance.RouletteDto;
 import keeper.project.homepage.dto.result.CommonResult;
 import keeper.project.homepage.dto.result.SingleResult;
@@ -41,12 +42,12 @@ public class GameController {
 
   @Secured("ROLE_회원")
   @GetMapping(value = "/dice/save")
-  public CommonResult saveResult(@RequestParam("result") Integer result,
+  public SingleResult<Integer> saveResult(@RequestParam("result") Integer result,
       @RequestParam("bet") Integer bettingPoint) {
 
-    boolean ret = gameService.saveDiceGame(result, bettingPoint);
-    return ret ? responseService.getSuccessResult()
-        : responseService.getFailResult(-1, "베팅 금액이 1000을 초과하였습니다.");
+    Integer ret = gameService.saveDiceGame(result, bettingPoint);
+    return ret != -9999 ? responseService.getSuccessSingleResult(ret)
+        : responseService.getFailSingleResult(ret, -1, "베팅 금액이 1000을 초과하였습니다.");
   }
 
   @Secured("ROLE_회원")
@@ -87,7 +88,7 @@ public class GameController {
 
   @Secured("ROLE_회원")
   @GetMapping(value = "/lotto/play")
-  public SingleResult<Integer> playLotto() {
+  public SingleResult<LottoDto> playLotto() {
 
     return responseService.getSuccessSingleResult(gameService.playLottoGame());
   }

--- a/src/main/java/keeper/project/homepage/dto/attendance/LottoDto.java
+++ b/src/main/java/keeper/project/homepage/dto/attendance/LottoDto.java
@@ -2,7 +2,6 @@ package keeper.project.homepage.dto.attendance;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +12,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonInclude(Include.NON_NULL)
-public class RouletteDto {
+public class LottoDto {
 
-  private Integer roulettePerDay;
-  private List<Integer> roulettePoints;
-  private Integer roulettePointIdx;
+  private Integer lottoPointIdx;
   private Integer todayResult;
 }

--- a/src/main/java/keeper/project/homepage/entity/attendance/GameEntity.java
+++ b/src/main/java/keeper/project/homepage/entity/attendance/GameEntity.java
@@ -51,6 +51,18 @@ public class GameEntity {
   @Column(name = "last_play_time")
   private LocalDateTime lastPlayTime;
 
+  @Setter
+  @Column(name = "dice_day_point")
+  private Integer diceDayPoint;
+
+  @Setter
+  @Column(name = "roulette_day_point")
+  private Integer rouletteDayPoint;
+
+  @Setter
+  @Column(name = "lotto_day_point")
+  private Integer lottoDayPoint;
+
   public void increaseDiceTimes() {
     dicePerDay += 1;
   }
@@ -71,5 +83,8 @@ public class GameEntity {
     dicePerDay = 0;
     roulettePerDay = 0;
     lottoPerDay = 0;
+    diceDayPoint = 0;
+    rouletteDayPoint = 0;
+    lottoDayPoint = 0;
   }
 }

--- a/src/test/java/keeper/project/homepage/controller/attendance/GameControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/attendance/GameControllerTest.java
@@ -319,6 +319,7 @@ public class GameControllerTest extends ApiControllerTestSetUp {
         .nickName(nickName + epochTime)
         .emailAddress(emailAddress + epochTime)
         .studentId(studentId + epochTime)
+        .point(10000)
         .generation(0F)
         .memberJobs(new ArrayList<>(List.of(hasMemberJobEntity)))
         .build();

--- a/src/test/java/keeper/project/homepage/controller/attendance/GameControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/attendance/GameControllerTest.java
@@ -110,7 +110,8 @@ public class GameControllerTest extends ApiControllerTestSetUp {
             responseFields(
                 fieldWithPath("success").description("에러 발생이 아니면 항상 true"),
                 fieldWithPath("code").description("에러 발생이 아니면 항상 0"),
-                fieldWithPath("msg").description("에러 발생이 아니면 항상 성공하였습니다")
+                fieldWithPath("msg").description("에러 발생이 아니면 항상 성공하였습니다"),
+                fieldWithPath("data").description("오늘 포인트 총 결과")
             )));
   }
 
@@ -150,7 +151,8 @@ public class GameControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("data.roulettePoints").description(
                     "룰렛판에 들어갈 랜덤으로 생성된 포인트 배열 (length:8)"),
                 fieldWithPath("data.roulettePointIdx").description(
-                    "랜덤으로 하나 뽑은 포인트의 index (0~7중 랜덤 한 숫자)")
+                    "랜덤으로 하나 뽑은 포인트의 index (0~7중 랜덤 한 숫자)"),
+                fieldWithPath("data.todayResult").description("오늘 포인트 총 결과")
             )));
   }
 
@@ -222,7 +224,8 @@ public class GameControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("success").description("에러 발생이 아니면 항상 true"),
                 fieldWithPath("code").description("에러 발생이 아니면 항상 0"),
                 fieldWithPath("msg").description("에러 발생이 아니면 항상 성공하였습니다"),
-                fieldWithPath("data").description("로또 게임 결과(등수)")
+                fieldWithPath("data.lottoPointIdx").description("로또 게임 결과(등수)"),
+                fieldWithPath("data.todayResult").description("오늘 포인트 총 결과")
             )));
   }
 


### PR DESCRIPTION
하루 포인트 결과 출력 각각 추가
- 주사위 > `/v1/game/dice/save` 에 `data` 로
- 룰렛 > `/v1/game/roulette/play` 에 `data.todayResult` 로
- 로또 > `/v1/game/lotto/play` 에 `data.todayResult` 로

포인트 로그 기능 추가
- 각 게임 시작시 보유 포인트가 참가 포인트보다 작을경우 
- `{
    "success": false,
    "code": -1001,
    "msg": "잔여 포인트가 부족합니다."
}` 로 response