### PR TITLE
Feature/#192 썸네일이 포함된 response dto 수정

### DIFF
--- a/src/main/java/keeper/project/homepage/admin/dto/etc/StaticWriteSubtitleImageResult.java
+++ b/src/main/java/keeper/project/homepage/admin/dto/etc/StaticWriteSubtitleImageResult.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import keeper.project.homepage.admin.dto.etc.StaticWriteContentResult;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.ThumbnailEntity;
 import keeper.project.homepage.entity.etc.StaticWriteSubtitleImageEntity;
 import lombok.AllArgsConstructor;
@@ -21,20 +22,23 @@ public class StaticWriteSubtitleImageResult {
 
   private Long staticWriteTitleId;
 
-  private ThumbnailEntity thumbnail;
+  private String thumbnailPath;
 
   private Integer displayOrder;
 
   private List<StaticWriteContentResult> staticWriteContentResults = new ArrayList<>();
 
-  public StaticWriteSubtitleImageResult(StaticWriteSubtitleImageEntity staticWriteSubtitleImageEntity) {
+  public StaticWriteSubtitleImageResult(
+      StaticWriteSubtitleImageEntity staticWriteSubtitleImageEntity) {
     this.id = staticWriteSubtitleImageEntity.getId();
     this.subtitle = staticWriteSubtitleImageEntity.getSubtitle();
     this.staticWriteTitleId = staticWriteSubtitleImageEntity.getStaticWriteTitle().getId();
-    this.thumbnail = staticWriteSubtitleImageEntity.getThumbnail();
+    this.thumbnailPath =
+        ImageController.THUMBNAIL_PATH + staticWriteSubtitleImageEntity.getThumbnail().getId();
     this.displayOrder = staticWriteSubtitleImageEntity.getDisplayOrder();
-    if(staticWriteSubtitleImageEntity.getStaticWriteContents() != null) {
-      this.staticWriteContentResults = staticWriteSubtitleImageEntity.getStaticWriteContents().stream()
+    if (staticWriteSubtitleImageEntity.getStaticWriteContents() != null) {
+      this.staticWriteContentResults = staticWriteSubtitleImageEntity.getStaticWriteContents()
+          .stream()
           .map(StaticWriteContentResult::new).collect(
               Collectors.toList());
     }

--- a/src/main/java/keeper/project/homepage/admin/dto/member/MemberDto.java
+++ b/src/main/java/keeper/project/homepage/admin/dto/member/MemberDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.member.MemberEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,7 +37,7 @@ public class MemberDto {
   private String rank;
   private String type;
   private List<String> jobs;
-  private Long thumbnailId;
+  private String thumbnailPath;
   private Integer merit;
   private Integer demerit;
   private Float generation;
@@ -70,7 +71,7 @@ public class MemberDto {
     this.generation = memberEntity.getGeneration();
 
     if (memberEntity.getThumbnail() != null) {
-      this.thumbnailId = memberEntity.getThumbnail().getId();
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
     }
     if (memberEntity.getMemberRank() != null) {
       this.rank = memberEntity.getMemberRank().getName();

--- a/src/main/java/keeper/project/homepage/common/controller/util/ImageController.java
+++ b/src/main/java/keeper/project/homepage/common/controller/util/ImageController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/util")
 public class ImageController {
 
+  public final static String THUMBNAIL_PATH = "/v1/util/thumbnail/";
+
   private final FileService fileService;
   private final ThumbnailService thumbnailService;
 

--- a/src/main/java/keeper/project/homepage/user/dto/attendance/RankDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/attendance/RankDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.member.MemberEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,7 @@ public class RankDto {
 
   private Long id;
   private String nickName;
-  private Long thumbnailId;
+  private String thumbnailPath;
   private List<String> jobs;
   private Integer point;
   private Integer rank;
@@ -32,7 +33,7 @@ public class RankDto {
     this.nickName = memberEntity.getNickName();
     this.point = memberEntity.getPoint();
     if (memberEntity.getThumbnail() != null) {
-      this.thumbnailId = memberEntity.getThumbnail().getId();
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
     }
     if (memberEntity.getMemberJobs() != null || memberEntity.getMemberJobs().isEmpty() == false) {
       this.jobs = new ArrayList<>();

--- a/src/main/java/keeper/project/homepage/user/dto/library/BookResult.java
+++ b/src/main/java/keeper/project/homepage/user/dto/library/BookResult.java
@@ -2,6 +2,7 @@ package keeper.project.homepage.user.dto.library;
 
 import java.time.LocalDateTime;
 import java.util.Date;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.library.BookEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +26,7 @@ public class BookResult {
   private Long borrow;
   private Long enable;
   private Date registerDate;
-  private Long thumbnailId;
+  private String thumbnailPath;
 
   public void initWithEntity(BookEntity bookEntity) {
     this.id = bookEntity.getId();
@@ -40,7 +41,7 @@ public class BookResult {
     this.enable = bookEntity.getEnable();
     this.registerDate = bookEntity.getRegisterDate();
     if (bookEntity.getThumbnailId() != null) {
-      this.thumbnailId = bookEntity.getThumbnailId().getId();
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + bookEntity.getThumbnailId().getId();
     }
 
   }

--- a/src/main/java/keeper/project/homepage/user/dto/member/MemberDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/MemberDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.member.MemberEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,7 +37,7 @@ public class MemberDto {
   private String rank;
   private String type;
   private List<String> jobs;
-  private Long thumbnailId;
+  private String thumbnailPath;
   private Integer merit;
   private Integer demerit;
   private Float generation;
@@ -70,7 +71,7 @@ public class MemberDto {
     this.generation = memberEntity.getGeneration();
 
     if (memberEntity.getThumbnail() != null) {
-      this.thumbnailId = memberEntity.getThumbnail().getId();
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
     }
     if (memberEntity.getMemberRank() != null) {
       this.rank = memberEntity.getMemberRank().getName();

--- a/src/main/java/keeper/project/homepage/user/dto/member/OtherMemberInfoResult.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/OtherMemberInfoResult.java
@@ -1,6 +1,7 @@
 package keeper.project.homepage.user.dto.member;
 
 import java.util.Date;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.ThumbnailEntity;
 import keeper.project.homepage.entity.member.MemberEntity;
 import keeper.project.homepage.entity.member.MemberRankEntity;
@@ -28,7 +29,7 @@ public class OtherMemberInfoResult {
 
   private MemberRankEntity memberRankEntity;
 
-  private ThumbnailEntity thumbnailEntity;
+  private String thumbnailPath;
 
   private Float generation;
 
@@ -44,7 +45,9 @@ public class OtherMemberInfoResult {
     this.registerDate = memberEntity.getRegisterDate();
     this.memberTypeEntity = memberEntity.getMemberType();
     this.memberRankEntity = memberEntity.getMemberRank();
-    this.thumbnailEntity = memberEntity.getThumbnail();
+    if (memberEntity.getThumbnail() != null) {
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
+    }
     this.generation = memberEntity.getGeneration();
   }
 

--- a/src/main/java/keeper/project/homepage/user/dto/posting/CommentDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/posting/CommentDto.java
@@ -3,6 +3,7 @@ package keeper.project.homepage.user.dto.posting;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.time.LocalDateTime;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.ThumbnailEntity;
 import keeper.project.homepage.entity.member.MemberEntity;
 import keeper.project.homepage.entity.posting.CommentEntity;
@@ -28,7 +29,7 @@ public class CommentDto {
   private Long parentId;
   private String writer;
   private Long writerId;
-  private Long writerThumbnailId;
+  private String writerThumbnailPath;
   private Boolean checkedLike;
   private Boolean checkedDislike;
 
@@ -59,7 +60,7 @@ public class CommentDto {
       this.writerId = member.getId();
       ThumbnailEntity thumbnail = member.getThumbnail();
       if (thumbnail != null) {
-        this.writerThumbnailId = thumbnail.getId();
+        this.writerThumbnailPath = ImageController.THUMBNAIL_PATH + thumbnail.getId().toString();
       }
     }
   }

--- a/src/main/java/keeper/project/homepage/user/dto/posting/PostingBestDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/posting/PostingBestDto.java
@@ -1,6 +1,7 @@
 package keeper.project.homepage.user.dto.posting;
 
 import java.time.LocalDateTime;
+import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.posting.PostingEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,26 +19,26 @@ public class PostingBestDto {
   private Long id;
   private String title;
   private String user;
-  private Long userThumbnailID;
+  private String userThumbnailPath;
   private LocalDateTime dateTime;
   private Integer watch;
   private Integer commentN;
   private Long categoryId;
   private String category;
-  private Long ThumbnailId;
+  private String thumbnailPath;
 
   public void initWithEntity(PostingEntity postingEntity) {
     this.id = postingEntity.getId();
     this.title = postingEntity.getTitle();
     this.user = postingEntity.getWriter();
-    this.userThumbnailID = postingEntity.getWriterThumbnailId();
+    this.userThumbnailPath = ImageController.THUMBNAIL_PATH + postingEntity.getWriterThumbnailId();
     this.dateTime = postingEntity.getRegisterTime();
     this.watch = postingEntity.getVisitCount();
     this.commentN = postingEntity.getCommentCount();
     this.categoryId = postingEntity.getCategoryId().getId();
     this.category = postingEntity.getCategoryId().getName();
     if (postingEntity.getThumbnail() != null) {
-      this.ThumbnailId = postingEntity.getThumbnail().getId();
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + postingEntity.getThumbnail().getId();
     }
   }
 }

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -398,10 +398,10 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
         fieldWithPath(prefix + ".likeCount").description("좋아요 개수"),
         fieldWithPath(prefix + ".dislikeCount").description("싫어요 개수"),
         fieldWithPath(prefix + ".parentId").description("대댓글인 경우, 부모 댓글의 id"),
-        fieldWithPath(prefix + ".writer").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
-        fieldWithPath(prefix + ".writerId").optional().description("작성자 (탈퇴한 작성자일 경우 null)"),
-        fieldWithPath(prefix + ".writerThumbnailId").optional().type(Long.TYPE)
-            .description("작성자 (탈퇴했을 경우 / 썸네일을 등록하지 않았을 경우 null)")));
+        fieldWithPath(prefix + ".writer").optional().description("작성자의 닉네임 (탈퇴한 작성자일 경우 null)"),
+        fieldWithPath(prefix + ".writerId").optional().description("작성자 id (탈퇴한 작성자일 경우 null)"),
+        fieldWithPath(prefix + ".writerThumbnailPath").optional().type(String.class)
+            .description("작성자의 썸네일 조회 api 경로 (탈퇴했을 경우 / 썸네일을 등록하지 않았을 경우 null)")));
     if (descriptors.length > 0) {
       commonFields.addAll(Arrays.asList(descriptors));
     }

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -310,7 +310,7 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
         fieldWithPath(prefix + ".merit").description("상점"),
         fieldWithPath(prefix + ".demerit").description("벌점"),
         fieldWithPath(prefix + ".generation").description("기수 (7월 이후는 N.5기)"),
-        fieldWithPath(prefix + ".thumbnailId").description("회원의 썸네일 이미지 아이디"),
+        fieldWithPath(prefix + ".thumbnailPath").description("회원의 썸네일 이미지 조회 api path"),
         fieldWithPath(prefix + ".rank").description("회원 등급: null, 우수회원, 일반회원"),
         fieldWithPath(prefix + ".type").description("회원 상태: null, 비회원, 정회원, 휴면회원, 졸업회원, 탈퇴"),
         fieldWithPath(prefix + ".jobs").description(
@@ -338,7 +338,8 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
         fieldWithPath(prefix + ".checkFollower").description(
             "상대방이 나를 팔로우 했는지 확인(팔로우: true, 아니면: false)"),
         fieldWithPath(prefix + ".generation").description("기수 (7월 이후는 N.5기)").optional(),
-        subsectionWithPath(prefix + ".thumbnailEntity").description("해당 유저의 썸네일 이미지").optional(),
+        fieldWithPath(prefix + ".thumbnailPath").description("해당 유저의 썸네일 이미지 조회 api path")
+            .optional(),
         subsectionWithPath(prefix + ".memberRankEntity").description(
             "해당 유저의 등급(id): 일반회원(1), 우수회원(2)").optional(),
         subsectionWithPath(prefix + ".memberTypeEntity").description(

--- a/src/test/java/keeper/project/homepage/admin/controller/about/AdminAboutSubtitleControllerTest.java
+++ b/src/test/java/keeper/project/homepage/admin/controller/about/AdminAboutSubtitleControllerTest.java
@@ -192,8 +192,8 @@ public class AdminAboutSubtitleControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("data.subtitle").description("생성에 성공한 페이지 블럭 서브 타이틀의 부제목"),
                 fieldWithPath("data.staticWriteTitleId").description(
                     "생성에 성공한 페이지 블럭 서브 타이틀과 연결된 페이지 블럭 타이틀의 ID"),
-                subsectionWithPath("data.thumbnail").description(
-                    "생성에 성공한 페이지 블럭 서브 타이틀과 연결된 썸네일 데이터"),
+                subsectionWithPath("data.thumbnailPath").description(
+                    "생성에 성공한 페이지 블럭 서브 타이틀과 연결된 썸네일 이미지를 조회하는 api path"),
                 fieldWithPath("data.displayOrder").description("생성에 성공한 페이지 블럭 서브 타이틀이 보여지는 순서"),
                 subsectionWithPath("data.staticWriteContentResults[]").description(
                     "생성에 성공한 페이지 블럭 서브 타이틀과 연결된 페이지 블럭 컨텐츠 데이터 리스트")
@@ -306,8 +306,8 @@ public class AdminAboutSubtitleControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("data.subtitle").description("수정에 성공한 페이지 블럭 서브 타이틀의 부제목"),
                 fieldWithPath("data.staticWriteTitleId").description(
                     "수정에 성공한 페이지 블럭 서브 타이틀과 연결된 페이지 블럭 타이틀의 ID"),
-                subsectionWithPath("data.thumbnail").description(
-                    "수정에 성공한 페이지 블럭 서브 타이틀과 연결된 썸네일 데이터"),
+                subsectionWithPath("data.thumbnailPath").description(
+                    "수정에 성공한 페이지 블럭 서브 타이틀과 연결된 썸네일 이미지를 조회하는 api path"),
                 fieldWithPath("data.displayOrder").description("수정에 성공한 페이지 블럭 서브 타이틀이 보여지는 순서"),
                 subsectionWithPath("data.staticWriteContentResults[]").description(
                     "수정에 성공한 페이지 블럭 서브 타이틀과 연결된 페이지 블럭 컨텐츠 데이터 리스트")
@@ -365,8 +365,8 @@ public class AdminAboutSubtitleControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("data.subtitle").description("삭제에 성공한 페이지 블럭 서브 타이틀의 부제목"),
                 fieldWithPath("data.staticWriteTitleId").description(
                     "삭제에 성공한 페이지 블럭 서브 타이틀과 연결된 페이지 블럭 타이틀의 ID"),
-                subsectionWithPath("data.thumbnail").description(
-                    "삭제에 성공한 페이지 블럭 서브 타이틀과 연결된 썸네일 데이터"),
+                subsectionWithPath("data.thumbnailPath").description(
+                    "삭제에 성공한 페이지 블럭 서브 타이틀과 연결된 썸네일 이미지를 조회하는 api path"),
                 fieldWithPath("data.displayOrder").description("삭제에 성공한 페이지 블럭 서브 타이틀이 보여지는 순서"),
                 subsectionWithPath("data.staticWriteContentResults[]").description(
                     "삭제에 성공한 페이지 블럭 서브 타이틀과 연결된 페이지 블럭 컨텐츠 데이터 리스트")

--- a/src/test/java/keeper/project/homepage/controller/attendance/RankControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/attendance/RankControllerTest.java
@@ -73,7 +73,8 @@ public class RankControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("msg").description("에러 발생이 아니면 항상 성공하였습니다"),
                 fieldWithPath("list[].id").description("멤버 ID"),
                 fieldWithPath("list[].nickName").description("닉네임"),
-                fieldWithPath("list[].thumbnailId").description("멤버 썸네일").optional(),
+                fieldWithPath("list[].thumbnailPath").description("멤버 썸네일 이미지 조회 api path")
+                    .optional(),
                 fieldWithPath("list[].jobs[]").description("멤버 직책"),
                 fieldWithPath("list[].point").description("포인트"),
                 fieldWithPath("list[].rank").description("포인트 등수")
@@ -93,7 +94,7 @@ public class RankControllerTest extends ApiControllerTestHelper {
     );
 
     result.andExpect(MockMvcResultMatchers.status().isOk())
-        .andExpect(jsonPath("$.list.length()").value(memberCount-1)); // virtual member제거
+        .andExpect(jsonPath("$.list.length()").value(memberCount - 1)); // virtual member제거
   }
 
   private MemberEntity generateTestMember(int point) throws Exception {

--- a/src/test/java/keeper/project/homepage/controller/library/LibraryMainControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/library/LibraryMainControllerTest.java
@@ -183,7 +183,7 @@ public class LibraryMainControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].enable").description("대여 가능한 수"),
                 fieldWithPath("list[].registerDate").description("등록된 날짜"),
                 fieldWithPath("list[].department").description("도서 분류 코드").optional(),
-                fieldWithPath("list[].thumbnailId").description("썸네일 ID").optional()
+                fieldWithPath("list[].thumbnailPath").description("썸네일 조회 api path").optional()
             )));
   }
 
@@ -220,7 +220,7 @@ public class LibraryMainControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].enable").description("대여 가능한 수"),
                 fieldWithPath("list[].registerDate").description("등록된 날짜"),
                 fieldWithPath("list[].department").description("도서 분류 코드").optional(),
-                fieldWithPath("list[].thumbnailId").description("썸네일 ID").optional()
+                fieldWithPath("list[].thumbnailPath").description("썸네일 조회 api path").optional()
             )));
   }
 
@@ -255,7 +255,7 @@ public class LibraryMainControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("data.enable").description("대여 가능한 수"),
                 fieldWithPath("data.registerDate").description("등록된 날짜"),
                 fieldWithPath("data.department").description("도서 분류 코드").optional(),
-                fieldWithPath("data.thumbnailId").description("썸네일 ID").optional()
+                fieldWithPath("data.thumbnailPath").description("썸네일 조회 api path").optional()
             )));
   }
 }

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -624,14 +624,16 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("code").description("성공 : 0, 실패 시 : -1"),
                 fieldWithPath("list[].id").description("게시물 ID"),
                 fieldWithPath("list[].title").description("제목"),
-                fieldWithPath("list[].userThumbnailID").description("작성자 썸네일 ID").optional(),
+                fieldWithPath("list[].userThumbnailPath").description("작성자 썸네일 이미지 조회 api path")
+                    .optional(),
                 fieldWithPath("list[].user").description("작성자"),
                 fieldWithPath("list[].dateTime").description("작성 시간"),
                 fieldWithPath("list[].watch").description("조회 수"),
                 fieldWithPath("list[].commentN").description("댓글 개수"),
                 fieldWithPath("list[].categoryId").description("카테고리 ID"),
                 fieldWithPath("list[].category").description("카테고리명"),
-                fieldWithPath("list[].thumbnailId").description("게시글 썸네일 id").optional()
+                fieldWithPath("list[].thumbnailPath").description("게시글 썸네일 이미지 조회 api path")
+                    .optional()
             )
         ));
   }


### PR DESCRIPTION
## 연관 issue
issue #192
(아직 모두 수정한 게 아니라서 close하지 않았습니다.)

## 프론트 전달사항
아래의 케이스에서 Response content thumbnail id 대신 thumbnail 이미지를 조회하는 api의 path를 포함하도록 수정하였습니다.
ex) `thumbnailId : {thumbnailId}` -> `thumbnailPath : "/v1/utils/thumbnail/{thumbnailId}"`
- 댓글 : 작성자(회원)의 썸네일
- 도서 : (도서 조회 시) 책의 썸네일
- 회원 : 회원의 썸네일
- 게시글 : (Best 게시글 조회 시) 게시글 작성자의 썸네일, 게시글의 썸네일
- 회원 랭킹 조회 : 회원의 썸네일
- subtitle 썸네일 이미지

아래의 케이스는 나중에 추가로 수정하겠습니다!
- 도서 : 관리자 권한이 필요한 도서 관리 api의 response
- 게시글 : Best 게시글 조회 외 api의 response

## 그 외
- 아직 thumbnail path로 수정하지 못한 케이스들은 response를 Entity로 전달하고 있습니다. 나중에 dto로 변경이 되면 수정하겠습니다.
(커밋이 많지만 다 비슷한 & 자잘한 수정들이라 양해 부탁드립니다..!)