### PR TITLE
Feature/#221 게시판 response dto

### DIFF
--- a/src/main/java/keeper/project/homepage/entity/posting/PostingEntity.java
+++ b/src/main/java/keeper/project/homepage/entity/posting/PostingEntity.java
@@ -51,15 +51,6 @@ public class PostingEntity {
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   private MemberEntity memberId;
   // DB 테이블과 별도의 변수 - Transient Annotation
-  @Transient
-  private String writer;
-  @Transient
-  private Long writerId;
-  @Transient
-  private Long writerThumbnailId;
-  @Setter
-  @Transient
-  private Integer size;
   @Column
   private Integer visitCount;
   @Column
@@ -91,9 +82,6 @@ public class PostingEntity {
   @JoinColumn(name = "category_id")
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   private CategoryEntity categoryId;
-  @Setter
-  @Transient
-  private String category;
   @OneToOne
   @JoinColumn(name = "thumbnail_id")
   @Setter
@@ -168,22 +156,5 @@ public class PostingEntity {
   public void decreaseDislikeCount() {
     Assert.isTrue(this.dislikeCount > 0, "dislike_count mush be bigger than zero");
     this.dislikeCount -= 1;
-  }
-
-  public void setWriter(String writer) {
-    this.writer = writer;
-  }
-
-  public void setWriterId(Long writerId) {
-    this.writerId = writerId;
-  }
-
-  public void setWriterThumbnailId(Long writerThumbnailId) {
-    this.writerThumbnailId = writerThumbnailId;
-  }
-
-  public void makeSecret() {
-//    this.title = "비밀 게시글입니다.";
-    this.content = "비밀 게시글입니다.";
   }
 }

--- a/src/main/java/keeper/project/homepage/user/dto/posting/PostingBestDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/posting/PostingBestDto.java
@@ -29,8 +29,8 @@ public class PostingBestDto {
   public void initWithEntity(PostingEntity postingEntity) {
     this.id = postingEntity.getId();
     this.title = postingEntity.getTitle();
-    this.user = postingEntity.getWriter();
-    this.userThumbnailID = postingEntity.getWriterThumbnailId();
+//    this.user = postingEntity.getWriter();
+//    this.userThumbnailID = postingEntity.getWriterThumbnailId();
     this.dateTime = postingEntity.getRegisterTime();
     this.watch = postingEntity.getVisitCount();
     this.commentN = postingEntity.getCommentCount();

--- a/src/main/java/keeper/project/homepage/user/dto/posting/PostingResponseDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/posting/PostingResponseDto.java
@@ -1,0 +1,100 @@
+package keeper.project.homepage.user.dto.posting;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.time.LocalDateTime;
+import java.util.List;
+import keeper.project.homepage.entity.FileEntity;
+import keeper.project.homepage.entity.ThumbnailEntity;
+import keeper.project.homepage.entity.posting.PostingEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(Include.NON_NULL)
+public class PostingResponseDto {
+
+  private static final String thumbnailApiPath = "/v1/util/thumbnail/";
+
+  private Long id;
+  private String title;
+  private String content;
+  private String writer;
+  private Long writerId;
+  private String writerThumbnailPath;
+  private Integer size;
+  private Integer visitCount;
+  private Integer likeCount;
+  private Integer dislikeCount;
+  private Integer commentCount;
+  private LocalDateTime registerTime;
+  private LocalDateTime updateTime;
+  private String ipAddress;
+  private Integer allowComment;
+  private Integer isNotice;
+  private Integer isSecret;
+  private Integer isTemp;
+  private String category;
+  private String thumbnailPath;
+  private List<FileEntity> files;
+
+  public PostingResponseDto initWithEntity(PostingEntity postingEntity, Integer size) {
+
+    ThumbnailEntity memberThumbnail = postingEntity.getMemberId().getThumbnail();
+    ThumbnailEntity postingThumbnail = postingEntity.getThumbnail();
+
+    PostingResponseDto postingResponseDto = PostingResponseDto.builder()
+        .id(postingEntity.getId())
+        .title(postingEntity.getTitle())
+        .content(postingEntity.getContent())
+        .writer(postingEntity.getMemberId().getNickName())
+        .writerId(postingEntity.getMemberId().getId())
+        .writerThumbnailPath(null)
+        .size(size)
+        .visitCount(postingEntity.getVisitCount())
+        .likeCount(postingEntity.getLikeCount())
+        .dislikeCount(postingEntity.getDislikeCount())
+        .commentCount(postingEntity.getCommentCount())
+        .registerTime(postingEntity.getRegisterTime())
+        .updateTime(postingEntity.getUpdateTime())
+        .ipAddress(postingEntity.getIpAddress())
+        .allowComment(postingEntity.getAllowComment())
+        .isNotice(postingEntity.getIsNotice())
+        .isSecret(postingEntity.getIsSecret())
+        .isTemp(postingEntity.getIsTemp())
+        .category(postingEntity.getCategoryId().getName())
+        .files(postingEntity.getFiles())
+        .thumbnailPath(null)
+        .build();
+
+    // 썸네일 경로 처리
+    if (memberThumbnail != null) {
+      postingResponseDto.setWriterThumbnailPath(thumbnailApiPath + memberThumbnail.getId());
+    }
+
+    if (postingThumbnail != null) {
+      postingResponseDto.setThumbnailPath(thumbnailApiPath + postingThumbnail.getId());
+    }
+
+    // 비밀게시판 처리
+    if (postingEntity.getCategoryId().getName().equals("비밀게시판")) {
+      postingResponseDto.setWriter("익명");
+      postingResponseDto.setWriterId(-1L);
+      postingResponseDto.setWriterThumbnailPath("");
+    }
+
+    // 비밀글 처리
+    if (postingEntity.getIsSecret() == 1) {
+      postingResponseDto.setContent("비밀 게시글입니다.");
+    }
+
+    return postingResponseDto;
+  }
+}

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -488,8 +490,10 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].category").description("카테고리 이름"),
                 fieldWithPath("list[].writer").optional().description("작성자 (비밀 게시글일 경우 익명)"),
                 fieldWithPath("list[].writerId").optional().description("작성자 (비밀 게시글일 경우 null)"),
-                fieldWithPath("list[].writerThumbnailId").optional()
-                    .description("작성자 (비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].writerThumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("작성자 썸네일 경로(비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].thumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("게시물 썸네일 경로 / 썸네일 등록하지 않았을 경우 null"),
                 fieldWithPath("list[].visitCount").description("조회 수"),
                 fieldWithPath("list[].likeCount").description("좋아요 수"),
                 fieldWithPath("list[].dislikeCount").description("싫어요 수"),
@@ -504,8 +508,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional(),
-                subsectionWithPath("list[].thumbnail").description("게시글 썸네일 (.id)").optional()
+                    .optional()
             )
         ));
   }
@@ -539,8 +542,10 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].category").description("카테고리 이름"),
                 fieldWithPath("list[].writer").description("작성자  (비밀 게시글일 경우 익명)"),
                 fieldWithPath("list[].writerId").optional().description("작성자 (비밀 게시글일 경우 null)"),
-                fieldWithPath("list[].writerThumbnailId").optional()
-                    .description("작성자 (비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].writerThumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("작성자 썸네일 경로(비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].thumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("게시물 썸네일 경로 / 썸네일 등록하지 않았을 경우 null"),
                 fieldWithPath("list[].visitCount").description("조회 수"),
                 fieldWithPath("list[].likeCount").description("좋아요 수"),
                 fieldWithPath("list[].dislikeCount").description("싫어요 수"),
@@ -555,8 +560,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional(),
-                subsectionWithPath("list[].thumbnail").description("게시글 썸네일 (.id)").optional()
+                    .optional()
             )
         ));
   }
@@ -585,8 +589,10 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].category").description("카테고리 이름"),
                 fieldWithPath("list[].writer").description("작성자  (비밀 게시글일 경우 익명)"),
                 fieldWithPath("list[].writerId").optional().description("작성자 (비밀 게시글일 경우 null)"),
-                fieldWithPath("list[].writerThumbnailId").optional()
-                    .description("작성자 (비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].writerThumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("작성자 썸네일 경로(비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].thumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("게시물 썸네일 경로 / 썸네일 등록하지 않았을 경우 null"),
                 fieldWithPath("list[].visitCount").description("조회 수"),
                 fieldWithPath("list[].likeCount").description("좋아요 수"),
                 fieldWithPath("list[].dislikeCount").description("싫어요 수"),
@@ -601,8 +607,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional(),
-                subsectionWithPath("list[].thumbnail").description("게시글 썸네일 (.id)").optional()
+                    .optional()
             )
         ));
   }
@@ -662,8 +667,10 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("data.category").description("카테고리 이름"),
                 fieldWithPath("data.writer").description("작성자  (비밀 게시글일 경우 익명)"),
                 fieldWithPath("data.writerId").optional().description("작성자 (비밀 게시글일 경우 null)"),
-                fieldWithPath("data.writerThumbnailId").optional()
-                    .description("작성자 (비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("data.writerThumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("작성자 썸네일 경로(비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("data.thumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("게시물 썸네일 경로 / 썸네일 등록하지 않았을 경우 null"),
                 fieldWithPath("data.visitCount").description("조회 수"),
                 fieldWithPath("data.likeCount").description("좋아요 수"),
                 fieldWithPath("data.dislikeCount").description("싫어요 수"),
@@ -678,8 +685,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("data.size").description("총 게시물 수(getPosting 에선 1개)"),
                 subsectionWithPath("data.files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional(),
-                subsectionWithPath("data.thumbnail").description("게시글 썸네일 (.id)").optional()
+                    .optional()
             )
         ));
   }
@@ -711,8 +717,10 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("data.category").description("카테고리 이름"),
                 fieldWithPath("data.writer").description("작성자  (비밀 게시글일 경우 익명)"),
                 fieldWithPath("data.writerId").optional().description("작성자 (비밀 게시글일 경우 null)"),
-                fieldWithPath("data.writerThumbnailId").optional()
-                    .description("작성자 (비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("data.writerThumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("작성자 썸네일 경로(비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("data.thumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("게시물 썸네일 경로 / 썸네일 등록하지 않았을 경우 null"),
                 fieldWithPath("data.visitCount").description("조회 수"),
                 fieldWithPath("data.likeCount").description("좋아요 수"),
                 fieldWithPath("data.dislikeCount").description("싫어요 수"),
@@ -727,8 +735,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("data.size").description("총 게시물 수(getPosting 에선 1개)"),
                 subsectionWithPath("data.files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional(),
-                subsectionWithPath("data.thumbnail").description("게시글 썸네일 (.id)").optional()
+                    .optional()
             )
         ));
   }
@@ -979,8 +986,10 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].category").description("카테고리 이름"),
                 fieldWithPath("list[].writer").description("작성자  (비밀 게시글일 경우 익명)"),
                 fieldWithPath("list[].writerId").optional().description("작성자 (비밀 게시글일 경우 null)"),
-                fieldWithPath("list[].writerThumbnailId").optional()
-                    .description("작성자 (비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].writerThumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("작성자 썸네일 경로(비밀 게시글일 경우 / 썸네일을 등록하지 않았을 경우 null)"),
+                fieldWithPath("list[].thumbnailPath").optional().type(JsonFieldType.STRING)
+                    .description("게시물 썸네일 경로 / 썸네일 등록하지 않았을 경우 null"),
                 fieldWithPath("list[].visitCount").description("조회 수"),
                 fieldWithPath("list[].likeCount").description("좋아요 수"),
                 fieldWithPath("list[].dislikeCount").description("싫어요 수"),
@@ -995,8 +1004,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional(),
-                subsectionWithPath("list[].thumbnail").description("게시글 썸네일 (.id)").optional()
+                    .optional()
             )
         ));
   }


### PR DESCRIPTION
- 프론트 요청사항에 맞추어 ThumbnailId 대신 API경로를 Payload에 담음
- Controller의 return Type을 PostingEntity -> PostingResponseDto로 변경
- Entity에 사용된 Transient 변수 모두 삭제
- PostingService에서 Response시 처리하던 setAllInfo함수 삭제, PostingResponseDto에서 dto 생성시 모두 처리하게끔 변경
- PostingBestDto는 병합시 문제(#222 와 충돌되는 문제)가 생김 ~ 추후에 처리 

## 연관 issue
issue : #221  
close : #221 

## 프론트 전달사항
**게시글 확인, 게시글 목록, 게시글 목록(최신글), 게시글 공지글 목록, 게시글 검색** 들에서 thumbnail id 대신 thumbnail 이미지를 조회하는 api의 path를 포함하도록 수정하였습니다.

`thumbnailId : {thumbnailId} -> thumbnailPath : "/v1/utils/thumbnail/{thumbnailId}"`
`writerThumbnailId : {thumbnailId} -> writerThumbnailPath : "/v1/utils/thumbnail/{thumbnailId}"`

참고 사진

**Before**
![image](https://user-images.githubusercontent.com/43947871/157881825-5f7a1811-b1fd-4689-82ab-99137316096f.png)


**After**
![image](https://user-images.githubusercontent.com/43947871/157881885-caa7dd15-fc70-488f-b2df-c713736e2d01.png)

> writerThumnailPath가 뜨지 않은것은 test에서 defaultThumbnail을 설정하지 않아서 그런것이니 실제에서는 문제가 없습니다.
