### PR TITLE
Feature/#218 팔로워 팔로잉 숫자 조회 기능 추가

### DIFF
--- a/src/docs/asciidoc/member_info.adoc
+++ b/src/docs/asciidoc/member_info.adoc
@@ -71,17 +71,17 @@ include::{snippets}/member-unfollow/response-fields.adoc[]
 
 ==== Request
 
-include::{snippets}/friend-show-followee/http-request.adoc[]
+include::{snippets}/member-show-followee/http-request.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/friend-show-followee/http-response.adoc[]
+include::{snippets}/member-show-followee/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/friend-show-followee/response-fields.adoc[]
+include::{snippets}/member-show-followee/response-fields.adoc[]
 
 == *팔로워 조회*
 
@@ -89,17 +89,35 @@ include::{snippets}/friend-show-followee/response-fields.adoc[]
 
 ==== Request
 
-include::{snippets}/friend-show-follower/http-request.adoc[]
+include::{snippets}/member-show-follower/http-request.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/friend-show-follower/http-response.adoc[]
+include::{snippets}/member-show-follower/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/friend-show-follower/response-fields.adoc[]
+include::{snippets}/member-show-follower/response-fields.adoc[]
+
+== *팔로우, 팔로워 숫자 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/member-follow-number/http-request.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/member-follow-number/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/member-follow-number/response-fields.adoc[]
 
 == *회원 탈퇴*
 

--- a/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import keeper.project.homepage.common.dto.sign.EmailAuthDto;
 import keeper.project.homepage.user.dto.member.MemberDto;
+import keeper.project.homepage.user.dto.member.MemberFollowDto;
 import keeper.project.homepage.user.dto.posting.PostingDto;
 import keeper.project.homepage.common.dto.result.CommonResult;
 import keeper.project.homepage.common.dto.result.ListResult;
@@ -72,6 +73,7 @@ public class MemberController {
         memberService.getOtherMemberInfoByRealName(realName));
   }
 
+  // TODO : 이거 삭제 (테스트 & 문서도)
   @Secured("ROLE_회원") // 각 리소스별 권한 설정
   @GetMapping(value = "/member")
   public SingleResult<MemberEntity> findMember() {
@@ -214,5 +216,13 @@ public class MemberController {
     Long id = authService.getMemberIdByJWT();
     memberDeleteService.deleteAccount(id, password);
     return responseService.getSuccessResult();
+  }
+
+  @Secured("ROLE_회원")
+  @GetMapping("/member/follow-number")
+  public SingleResult<MemberFollowDto> getFollowerAndFolloweeCount() {
+    Long id = authService.getMemberIdByJWT();
+    MemberFollowDto followDto = memberService.getFollowerAndFolloweeNumber(id);
+    return responseService.getSuccessSingleResult(followDto);
   }
 }

--- a/src/main/java/keeper/project/homepage/user/dto/member/MemberFollowDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/MemberFollowDto.java
@@ -1,0 +1,19 @@
+package keeper.project.homepage.user.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(Include.NON_NULL)
+public class MemberFollowDto {
+
+  Integer followeeNumber;
+  Integer followerNumber;
+}

--- a/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
+++ b/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
+import keeper.project.homepage.user.dto.member.MemberFollowDto;
 import keeper.project.homepage.util.ImageCenterCrop;
 import keeper.project.homepage.common.dto.sign.EmailAuthDto;
 import keeper.project.homepage.user.dto.member.MemberDto;
@@ -278,5 +279,21 @@ public class MemberService {
         postings.size());
 
     return page;
+  }
+
+  private Integer getFolloweeNumber(MemberEntity member) {
+    return member.getFollowee().size();
+  }
+
+  private Integer getFollowerNumber(MemberEntity member) {
+    return member.getFollower().size();
+  }
+
+  public MemberFollowDto getFollowerAndFolloweeNumber(Long id) {
+    MemberEntity member = findById(id);
+    return MemberFollowDto.builder()
+        .followeeNumber(getFolloweeNumber(member))
+        .followerNumber(getFollowerNumber(member))
+        .build();
   }
 }

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -407,4 +407,18 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
     }
     return commonFields;
   }
+
+  public List<FieldDescriptor> generateCommonFollowResponse(ResponseType type, String docSuccess,
+      String docCode, String docMsg, FieldDescriptor... descriptors) {
+    String prefix = type.getReponseFieldPrefix();
+    List<FieldDescriptor> commonFields = new ArrayList<>();
+    commonFields.addAll(generateCommonResponseFields(docSuccess, docCode, docMsg));
+    commonFields.addAll(Arrays.asList(
+        fieldWithPath(prefix + ".followerNumber").description("팔로워 숫자"),
+        fieldWithPath(prefix + ".followeeNumber").description("팔로우 숫자")));
+    if (descriptors.length > 0) {
+      commonFields.addAll(Arrays.asList(descriptors));
+    }
+    return commonFields;
+  }
 }

--- a/src/test/java/keeper/project/homepage/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/member/MemberControllerTest.java
@@ -290,4 +290,36 @@ public class MemberControllerTest extends MemberControllerTestSetup {
       memberService.findById(memberEntity.getId());
     });
   }
+
+  @Test
+  @DisplayName("팔로워, 팔로우 숫자 조회하기")
+  public void getFollowerAndFolloweeCount() throws Exception {
+    int followerNum = 3;
+    int followeeNum = 2;
+    for (int i = 0; i < followerNum; i++) {
+      MemberEntity follower = generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원,
+          MemberRankName.일반회원);
+      memberService.follow(follower.getId(), memberEntity.getLoginId());
+    }
+    for (int i = 0; i < followeeNum; i++) {
+      MemberEntity followee = generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원,
+          MemberRankName.일반회원);
+      memberService.follow(memberEntity.getId(), followee.getLoginId());
+    }
+
+    // TODO : 예외 처리 & doc 메세지 채우기 (회원 관리 전체적으로 예외 수정할 예정)
+    String docMsg = "";
+    String docCode = "실패한 경우: " + exceptionAdvice.getMessage("unKnown.code");
+    mockMvc.perform(get("/v1/member/follow-number")
+            .header("Authorization", userToken))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.followerNumber").value(followerNum))
+        .andExpect(jsonPath("$.data.followeeNumber").value(followeeNum))
+        .andDo(document("member-follow-number",
+            responseFields(
+                generateCommonFollowResponse(ResponseType.SINGLE, "성공 시: success, 실패 시: fail",
+                    docCode, docMsg)
+            )));
+  }
 }


### PR DESCRIPTION
## 연관 issue
close #228 
issue #218 
(#218 은 게시글 조회 추가 후 닫겠습니다)

## 프론트 전달사항
- 팔로워, 팔로잉 숫자 조회 기능 추가
  - api path : `/v1/member/follow-number`
  - api doc 경로 : 
`회원 관리` > `회원 정보 조회 및 기타 API` > `팔로우, 팔로워 숫자 조회`

## 그 외
- API 문서 맛 간 거 : adoc 경로가 잘못 되어있었습니다. 수정했습니다!