### PR TITLE
feat : 최신 공지글 목록 기능 추가

### DIFF
--- a/src/main/java/keeper/project/homepage/repository/posting/PostingRepository.java
+++ b/src/main/java/keeper/project/homepage/repository/posting/PostingRepository.java
@@ -15,6 +15,8 @@ public interface PostingRepository extends JpaRepository<PostingEntity, Long> {
 
   Page<PostingEntity> findAllByIsTemp(Integer isTemp, Pageable pageable);
 
+  List<PostingEntity> findAllByIsNoticeAndIsTemp(Integer isNotice, Integer isTemp);
+
   Page<PostingEntity> findAllByCategoryIdAndIsTempAndIsNotice(CategoryEntity category,
       Integer isTemp, Integer isNotice, Pageable pageable);
 
@@ -34,7 +36,7 @@ public interface PostingRepository extends JpaRepository<PostingEntity, Long> {
       Integer isTemp, Integer isNotice, Pageable pageable);
 
   Page<PostingEntity> findAllByCategoryIdAndMemberIdAndIsTempAndIsNotice(CategoryEntity category,
-      MemberEntity member, Integer isTemp,Integer isNotice, Pageable pageable);
+      MemberEntity member, Integer isTemp, Integer isNotice, Pageable pageable);
 
   List<PostingEntity> findAllByMemberId(MemberEntity member);
 

--- a/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
@@ -33,6 +33,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -84,10 +85,15 @@ public class PostingController {
 
   @GetMapping(value = "/notice")
   public ListResult<PostingResponseDto> findAllNoticePostingByCategoryId(
-      @RequestParam("category") Long categoryId) {
+      @SortDefault(sort = "registerTime", direction = Direction.DESC)
+      @RequestParam(value = "category", required = false) Long categoryId) {
 
-    return responseService.getSuccessListResult(
-        postingService.findAllNoticeByCategoryId(categoryId));
+    if (categoryId == null) {
+      return responseService.getSuccessListResult(postingService.findAllNotice());
+    } else {
+      return responseService.getSuccessListResult(
+          postingService.findAllNoticeByCategoryId(categoryId));
+    }
   }
 
   @GetMapping(value = "/best")

--- a/src/main/java/keeper/project/homepage/user/service/posting/PostingService.java
+++ b/src/main/java/keeper/project/homepage/user/service/posting/PostingService.java
@@ -84,6 +84,20 @@ public class PostingService {
     return postingResponseDtos;
   }
 
+  public List<PostingResponseDto> findAllNotice() {
+
+    List<PostingEntity> postingEntities = postingRepository.findAllByIsNoticeAndIsTemp(
+        isNoticePosting, isNotTempPosting);
+    List<PostingResponseDto> postingResponseDtos = new ArrayList<>();
+
+    for (PostingEntity postingEntity : postingEntities) {
+      postingResponseDtos.add(new PostingResponseDto().initWithEntity(postingEntity,
+          postingEntities.size()));
+    }
+
+    return postingResponseDtos;
+  }
+
   public List<PostingResponseDto> findAllNoticeByCategoryId(Long categoryId) {
 
     CategoryEntity categoryEntity = categoryRepository.findById(categoryId)

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -566,7 +566,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
   }
 
   @Test
-  @DisplayName("카테고리별 공지글 목록 불러오기")
+  @DisplayName("공지글 목록 불러오기(카테고리별 or 전부)")
   public void findAllNoticePostingByCategoryId() throws Exception {
 
     ResultActions result = mockMvc.perform(get("/v1/post/notice")
@@ -577,7 +577,7 @@ public class PostingControllerTest extends ApiControllerTestSetUp {
         .andDo(print())
         .andDo(document("post-getNotice",
             requestParameters(
-                parameterWithName("category").description("게시판 종류 ID")
+                parameterWithName("category").description("게시판 종류 ID / 주지 않을시 전체 카테고리 공지글 불러옴")
             ),
             responseFields(
                 fieldWithPath("success").description("성공: true +\n실패: false"),


### PR DESCRIPTION
## 연관 issue
issue: #230
close: #230

## 프론트 전달사항
기존의 [게시글 공지글 목록 API] - `/v1/post/notice` 에서 `category` parameter를 아무것도 주지 않을시, 카테고리별이 아닌 전체 공지글을 생성시간 내림차순으로 정렬하여 보내줍니다.