### PR TITLE
Feature/#218 다른 회원 게시글 조회 기능 추가

### DIFF
--- a/src/docs/asciidoc/member_posting.adoc
+++ b/src/docs/asciidoc/member_posting.adoc
@@ -122,3 +122,47 @@ include::{snippets}/member-delete-post/path-parameters.adoc[]
 ==== Response
 
 include::{snippets}/member-delete-post/http-response.adoc[]
+
+== *다른 회원이 작성한 게시글 목록 조회하기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/member-other-posts-list/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/member-other-posts-list/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/member-other-posts-list/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/member-other-posts-list/response-fields.adoc[]
+
+== *다른 회원이 작성한 게시글 상세 조회하기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/member-other-posts-single/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/member-other-posts-single/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/member-other-posts-single/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/member-other-posts-single/response-fields.adoc[]

--- a/src/main/java/keeper/project/homepage/repository/posting/PostingRepository.java
+++ b/src/main/java/keeper/project/homepage/repository/posting/PostingRepository.java
@@ -34,9 +34,12 @@ public interface PostingRepository extends JpaRepository<PostingEntity, Long> {
       Integer isTemp, Integer isNotice, Pageable pageable);
 
   Page<PostingEntity> findAllByCategoryIdAndMemberIdAndIsTempAndIsNotice(CategoryEntity category,
-      MemberEntity member, Integer isTemp,Integer isNotice, Pageable pageable);
+      MemberEntity member, Integer isTemp, Integer isNotice, Pageable pageable);
 
   List<PostingEntity> findAllByMemberId(MemberEntity member);
+
+  Page<PostingEntity> findAllByMemberIdAndIsTempAndIsSecret(
+      MemberEntity member, Integer isTemp, Integer isSecret, Pageable pageable);
 
   List<PostingEntity> findAllByIsTempAndIsSecretAndIsNoticeAndRegisterTimeBetween(Integer isTemp,
       Integer isSecret, Integer isNotice, LocalDateTime registerTime, LocalDateTime registerTime2);

--- a/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
@@ -11,6 +11,7 @@ import keeper.project.homepage.user.dto.member.OtherMemberInfoResult;
 import keeper.project.homepage.common.dto.result.SingleResult;
 import keeper.project.homepage.entity.member.MemberEntity;
 import keeper.project.homepage.common.service.ResponseService;
+import keeper.project.homepage.user.dto.posting.PostingResponseDto;
 import keeper.project.homepage.user.service.member.MemberDeleteService;
 import keeper.project.homepage.user.service.posting.PostingService;
 import keeper.project.homepage.common.service.util.AuthService;
@@ -45,6 +46,7 @@ public class MemberController {
   private final MemberDeleteService memberDeleteService;
   private final ResponseService responseService;
   private final AuthService authService;
+  private final PostingService postingService;
 
   @Secured("ROLE_회원")
   @GetMapping(value = "/members")
@@ -214,5 +216,26 @@ public class MemberController {
     Long id = authService.getMemberIdByJWT();
     memberDeleteService.deleteAccount(id, password);
     return responseService.getSuccessResult();
+  }
+
+  @Secured("ROLE_회원")
+  @GetMapping("/member/{memberid}/posts")
+  public ListResult<PostingResponseDto> findPostingListOfOther(
+      @PathVariable("memberid") Long memberId,
+      @PageableDefault(size = 10, page = 0, sort = "registerTime", direction = Direction.DESC) Pageable pageable
+  ) {
+    MemberEntity other = memberService.findById(memberId);
+    List<PostingResponseDto> postingList = postingService.findAllByMemberId(other, pageable);
+    return responseService.getSuccessListResult(postingList);
+  }
+
+  @Secured("ROLE_회원")
+  @GetMapping("/member/{memberid}/posts/{postid}")
+  public SingleResult<PostingResponseDto> findSinglePostingOfOther(
+      @PathVariable("memberid") Long memberId,
+      @PathVariable("postid") Long postId) {
+    PostingResponseDto posting = postingService.findByPostId(postId);
+    System.out.println("In Controller : " + posting.getId());
+    return responseService.getSuccessSingleResult(posting);
   }
 }

--- a/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
@@ -219,9 +219,9 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping("/member/{memberid}/posts")
+  @GetMapping("/member/{memberId}/posts")
   public ListResult<PostingResponseDto> findPostingListOfOther(
-      @PathVariable("memberid") Long memberId,
+      @PathVariable("memberId") Long memberId,
       @PageableDefault(size = 10, page = 0, sort = "registerTime", direction = Direction.DESC) Pageable pageable
   ) {
     MemberEntity other = memberService.findById(memberId);
@@ -230,10 +230,10 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping("/member/{memberid}/posts/{postid}")
+  @GetMapping("/member/{memberId}/posts/{postId}")
   public SingleResult<PostingResponseDto> findSinglePostingOfOther(
-      @PathVariable("memberid") Long memberId,
-      @PathVariable("postid") Long postId) {
+      @PathVariable("memberId") Long memberId,
+      @PathVariable("postId") Long postId) {
     PostingResponseDto posting = postingService.findByPostId(postId);
     System.out.println("In Controller : " + posting.getId());
     return responseService.getSuccessSingleResult(posting);

--- a/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
+++ b/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
@@ -262,6 +262,8 @@ public class MemberService {
     // 출처: https://www.baeldung.com/java-random-string
   }
 
+  // TODO : 모든 PostingDto -> PostingResponseDto 로 변경하기
+  // TODO : return type : List<PostingDto> & return page.getContent(); 로 수정
   public Page<PostingDto> findAllPostingByIsTemp(Long id, Pageable pageable, Integer isTemp) {
     MemberEntity memberEntity = memberRepository.findById(id).orElseThrow(
         () -> new CustomMemberNotFoundException(id.toString() + "인 id를 가진 member가 존재하지 않습니다."));

--- a/src/main/java/keeper/project/homepage/user/service/posting/PostingService.java
+++ b/src/main/java/keeper/project/homepage/user/service/posting/PostingService.java
@@ -127,6 +127,27 @@ public class PostingService {
     return postingBestDtos;
   }
 
+  public PostingResponseDto findByPostId(Long postId) {
+    PostingEntity posting = getPostingById(postId);
+    // TODO : isTemp, isSecret 체크하는 예외처리 추가
+    // TODO : postingNotExist 예외처리 추가
+    // FIXME : request와 response용 dto를 나눴다면 initWithEntity() 대신 생성자로 초기화하는 게 좋을 것 같습니다
+    // TODO : postingResponseDto의 initWithEntity가 init하는 동작이 아니라 새로운 dto를 반환해주는 동작을 수행하고 있습니다
+    PostingResponseDto postingResponseDto = new PostingResponseDto();
+    return postingResponseDto.initWithEntity(posting, 1);
+  }
+
+  public List<PostingResponseDto> findAllByMemberId(MemberEntity memberEntity, Pageable pageable) {
+    Page<PostingEntity> postingPage = postingRepository.findAllByMemberIdAndIsTempAndIsSecret(
+        memberEntity, isNotTempPosting, isNotSecretPosting, pageable);
+    List<PostingResponseDto> postingList = new ArrayList<>();
+    for (PostingEntity posting : postingPage) {
+      PostingResponseDto dto = new PostingResponseDto();
+      postingList.add(dto.initWithEntity(posting, (int) postingPage.getTotalElements()));
+    }
+    return postingList;
+  }
+
   public PostingEntity save(PostingDto dto) {
 
     Optional<CategoryEntity> categoryEntity = categoryRepository.findById(
@@ -358,6 +379,7 @@ public class PostingService {
     return likeAndDislikeDto;
   }
 
+  // FIXME : authService.getMemberEntityWithJWT() 가 생겼습니다ㅏ
   private MemberEntity getMemberEntityWithJWT() {
     Long memberId = authService.getMemberIdByJWT();
     Optional<MemberEntity> member = memberRepository.findById(memberId);

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -246,7 +246,7 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
       Integer isNotice, Integer isSecret, Integer isTemp) {
     final String epochTime = Long.toHexString(System.nanoTime());
     final LocalDateTime now = LocalDateTime.now();
-    return postingRepository.save(PostingEntity.builder()
+    PostingEntity posting = postingRepository.save(PostingEntity.builder()
         .title("posting 제목 " + epochTime)
         .content("posting 내용 " + epochTime)
         .categoryId(category)
@@ -264,6 +264,8 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
         .password(postingPassword)
         .memberId(writer)
         .build());
+    writer.getPosting().add(posting);
+    return posting;
   }
 
   public CommentEntity generateCommentEntity(PostingEntity posting, MemberEntity writer,

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -371,7 +371,9 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
     return commonFields;
   }
 
-  public List<FieldDescriptor> generatePostingResponseFields(ResponseType type, String success,
+  // TODO : PostingDto -> PostingResponseDto로 바꾼 후, .._Legacy 메소드 삭제
+  public List<FieldDescriptor> generatePostingResponseFields_Legacy(ResponseType type,
+      String success,
       String code, String msg, FieldDescriptor... addDescriptors) {
     String prefix = type.getReponseFieldPrefix();
     List<FieldDescriptor> commonFields = new ArrayList<>();
@@ -398,6 +400,42 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
         fieldWithPath(prefix + ".categoryId").description("카테고리 아이디"),
         fieldWithPath(prefix + ".category").description("카테고리 이름"),
         fieldWithPath(prefix + ".thumbnailId").description("게시글 썸네일 아이디")
+    ));
+    if (addDescriptors.length > 0) {
+      commonFields.addAll(Arrays.asList(addDescriptors));
+    }
+    return commonFields;
+  }
+
+  public List<FieldDescriptor> generatePostingResponseFields(ResponseType type, String success,
+      String code, String msg, FieldDescriptor... addDescriptors) {
+    String prefix = type.getReponseFieldPrefix();
+    List<FieldDescriptor> commonFields = new ArrayList<>();
+    commonFields.addAll(generateCommonResponseFields(success, code, msg));
+    commonFields.addAll(Arrays.asList(
+        fieldWithPath(prefix + ".id").description("게시물 ID"),
+        fieldWithPath(prefix + ".title").description("게시물 제목"),
+        fieldWithPath(prefix + ".content").description("게시물 내용 (비밀 게시글일 경우 \"비밀 게시글입니다.\""),
+        fieldWithPath(prefix + ".writer").description("작성자 (비밀 게시글일 경우 \"익명\")"),
+        fieldWithPath(prefix + ".writerId").description("작성자 아이디 (비밀 게시글일 경우 -1)"),
+        fieldWithPath(prefix + ".writerThumbnailPath").description(
+            "작성자 썸네일 이미지 조회 api path (비밀 게시글일 경우 null)").type(String.class).optional(),
+        fieldWithPath(prefix + ".size").description("조건에 따라 조회한 게시글의 총 개수"),
+        fieldWithPath(prefix + ".visitCount").description("조회 수"),
+        fieldWithPath(prefix + ".likeCount").description("좋아요 수"),
+        fieldWithPath(prefix + ".dislikeCount").description("싫어요 수"),
+        fieldWithPath(prefix + ".commentCount").description("댓글 수"),
+        fieldWithPath(prefix + ".registerTime").description("작성 시간"),
+        fieldWithPath(prefix + ".updateTime").description("수정 시간"),
+        fieldWithPath(prefix + ".ipAddress").description("IP 주소"),
+        fieldWithPath(prefix + ".allowComment").description("댓글 허용?"),
+        fieldWithPath(prefix + ".isNotice").description("공지글?"),
+        fieldWithPath(prefix + ".isSecret").description("비밀글?"),
+        fieldWithPath(prefix + ".isTemp").description("임시저장?"),
+        fieldWithPath(prefix + ".category").description("카테고리 이름"),
+        fieldWithPath(prefix + ".thumbnailPath").description("게시글 썸네일 이미지 조회 api path")
+            .type(String.class).optional(),
+        fieldWithPath(prefix + ".files").description("첨부파일")
     ));
     if (addDescriptors.length > 0) {
       commonFields.addAll(Arrays.asList(addDescriptors));

--- a/src/test/java/keeper/project/homepage/ApiControllerTestSetUp.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestSetUp.java
@@ -33,6 +33,7 @@ import keeper.project.homepage.user.service.member.MemberHasCommentLikeService;
 import keeper.project.homepage.user.service.posting.CommentService;
 import keeper.project.homepage.common.service.sign.SignUpService;
 import keeper.project.homepage.user.service.member.MemberService;
+import keeper.project.homepage.user.service.posting.PostingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -131,6 +132,9 @@ public abstract class ApiControllerTestSetUp {
 
   @Autowired
   protected CommentService commentService;
+
+  @Autowired
+  protected PostingService postingService;
 
   /********* Others Start ********/
   @Autowired


### PR DESCRIPTION
## 연관 issue
close #218 

## 프론트 전달사항
- 다른 회원 게시글 목록 조회
  - url path : `/v1/member/{memberId}/posts`
  - docs path : 회원 관리 > 회원 정보 조회 및 기타 API > 다른 회원이 작성한 게시글 목록 조회하기

- 다른 회원 게시글 상세 조회
  - url path : `/v1/member/{memberId}/posts/{postId}`
  - docs path : 회원 관리 > 회원 정보 조회 및 기타 API > 다른 회원이 작성한 게시글 상세 조회하기