### PR TITLE
Feature/#187 회원정보조회수정

### DIFF
--- a/src/docs/asciidoc/member_info.adoc
+++ b/src/docs/asciidoc/member_info.adoc
@@ -141,6 +141,26 @@ include::{snippets}/member-delete/http-response.adoc[]
 
 include::{snippets}/member-delete/response-fields.adoc[]
 
+== *내 정보 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/member-info/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-info/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/member-info/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/member-info/response-fields.adoc[]
+
 == *권한 없이 회원 정보 목록 조회*
 
 === 요청
@@ -208,28 +228,3 @@ include::{snippets}/member-otherInfo-ById/response-body.adoc[]
 ==== Response Fields
 
 include::{snippets}/member-otherInfo-ById/response-fields.adoc[]
-
-== *다른 회원 정보 조회 (실제 이름을 통해)*
-
-=== 요청
-
-==== Request
-
-include::{snippets}/member-otherInfo-ByRealName/http-request.adoc[]
-
-==== Path Parameters
-
-include::{snippets}/member-otherInfo-ByRealName/path-parameters.adoc[]
-
-==== Response
-
-include::{snippets}/member-otherInfo-ByRealName/http-response.adoc[]
-
-==== Response Body
-
-include::{snippets}/member-otherInfo-ByRealName/response-body.adoc[]
-
-==== Response Fields
-
-include::{snippets}/member-otherInfo-ByRealName/response-fields.adoc[]
-

--- a/src/docs/asciidoc/member_infoAdmin.adoc
+++ b/src/docs/asciidoc/member_infoAdmin.adoc
@@ -18,3 +18,27 @@ endif::[]
 == API 목록
 
 link:memberAdmin.html[회원 API 목록으로 돌아가기]
+
+== *회원 정보 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/admin-members/http-request.adoc[]
+
+==== Request Parameters
+
+include::{snippets}/admin-members/request-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/admin-members/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/admin-members/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/admin-members/response-fields.adoc[]

--- a/src/main/java/keeper/project/homepage/admin/controller/member/AdminMemberController.java
+++ b/src/main/java/keeper/project/homepage/admin/controller/member/AdminMemberController.java
@@ -14,6 +14,9 @@ import keeper.project.homepage.entity.member.MemberEntity;
 import keeper.project.homepage.common.service.ResponseService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,9 +35,11 @@ public class AdminMemberController {
 
   @Secured("ROLE_회장") // 각 리소스별 권한 설정
   @GetMapping(value = "/members")
-  public ListResult<MemberEntity> findAllMember() {
+  public ListResult<MemberDto> getMembers(
+      @PageableDefault(size = 20, sort = "id", direction = Direction.DESC)Pageable pageable
+  ) {
     // 결과데이터가 여러건인경우 getSuccessListResult 이용해서 결과를 출력한다.
-    return responseService.getSuccessListResult(adminMemberService.findAll());
+    return responseService.getSuccessListResult(adminMemberService.getMembers(pageable));
   }
 
   @Secured("ROLE_회장")

--- a/src/main/java/keeper/project/homepage/admin/controller/member/AdminMemberController.java
+++ b/src/main/java/keeper/project/homepage/admin/controller/member/AdminMemberController.java
@@ -27,14 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Log4j2
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1/admin")
+@RequestMapping(value = "/v1/admin/members")
 public class AdminMemberController {
 
   private final AdminMemberService adminMemberService;
   private final ResponseService responseService;
 
   @Secured("ROLE_회장") // 각 리소스별 권한 설정
-  @GetMapping(value = "/members")
+  @GetMapping(value = "")
   public ListResult<MemberDto> getMembers(
       @PageableDefault(size = 20, sort = "id", direction = Direction.DESC)Pageable pageable
   ) {
@@ -43,21 +43,21 @@ public class AdminMemberController {
   }
 
   @Secured("ROLE_회장")
-  @PutMapping("/member/update/rank")
+  @PutMapping("/rank")
   public SingleResult<MemberDto> updateMemberRank(@RequestBody MemberRankDto memberRankDto) {
     MemberDto update = adminMemberService.updateMemberRank(memberRankDto);
     return responseService.getSuccessSingleResult(update);
   }
 
   @Secured("ROLE_회장")
-  @PutMapping("/member/update/type")
+  @PutMapping("/type")
   public SingleResult<MemberDto> updateMemberType(@RequestBody MemberTypeDto memberTypeDto) {
     MemberDto update = adminMemberService.updateMemberType(memberTypeDto);
     return responseService.getSuccessSingleResult(update);
   }
 
   @Secured("ROLE_회장")
-  @PutMapping("/member/update/job")
+  @PutMapping("/job")
   public SingleResult<MemberDto> updateMemberJob(@RequestBody MemberJobDto memberJobDto) {
 
     MemberDto update = adminMemberService.updateMemberJobs(memberJobDto);
@@ -65,7 +65,7 @@ public class AdminMemberController {
   }
 
   @Secured({"ROLE_회장", "ROLE_서기"})
-  @PutMapping("/member/update/generation")
+  @PutMapping("/generation")
   public SingleResult<MemberDto> updateMemberGeneration(
       @RequestBody MemberGenerationDto memberGenerationDto) {
     MemberDto update = adminMemberService.updateGeneration(memberGenerationDto);
@@ -73,7 +73,7 @@ public class AdminMemberController {
   }
 
   @Secured({"ROLE_회장", "ROLE_서기"})
-  @PutMapping("/member/update/merit")
+  @PutMapping("/merit")
   public SingleResult<MemberDto> updateMemberMerit(@RequestBody MemberMeritDto memberMeritDto) {
     MemberDto update = adminMemberService.updateMerit(memberMeritDto);
     return responseService.getSuccessSingleResult(update);
@@ -81,7 +81,7 @@ public class AdminMemberController {
 
 
   @Secured({"ROLE_회장", "ROLE_서기"})
-  @PutMapping("/member/update/demerit")
+  @PutMapping("/demerit")
   public SingleResult<MemberDto> updateMemberDemerit(
       @RequestBody MemberDemeritDto memberDemeritDto) {
     MemberDto update = adminMemberService.updateDemerit(memberDemeritDto);

--- a/src/main/java/keeper/project/homepage/admin/dto/member/MemberDto.java
+++ b/src/main/java/keeper/project/homepage/admin/dto/member/MemberDto.java
@@ -87,5 +87,39 @@ public class MemberDto {
     }
   }
 
+  public MemberDto(MemberEntity memberEntity) {
+    // 민감한 정보 포함
+    this.id = memberEntity.getId();
+    this.loginId = memberEntity.getLoginId();
+    this.password = null;//memberEntity.getPassword();
+    this.realName = memberEntity.getRealName();
+    this.nickName = memberEntity.getNickName();
+    this.birthday = memberEntity.getBirthday();
+    this.emailAddress = memberEntity.getEmailAddress();
+    this.studentId = memberEntity.getStudentId();
+    this.registerDate = memberEntity.getRegisterDate();
+    this.point = memberEntity.getPoint();
+    this.level = memberEntity.getLevel();
+    this.merit = memberEntity.getMerit();
+    this.demerit = memberEntity.getDemerit();
+    this.generation = memberEntity.getGeneration();
+
+    if (memberEntity.getThumbnail() != null) {
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
+    }
+    if (memberEntity.getMemberRank() != null) {
+      this.rank = memberEntity.getMemberRank().getName();
+    }
+    if (memberEntity.getMemberType() != null) {
+      this.type = memberEntity.getMemberType().getName();
+    }
+    if (memberEntity.getMemberJobs() != null || memberEntity.getMemberJobs().isEmpty() == false) {
+      this.jobs = new ArrayList<>();
+      memberEntity.getMemberJobs()
+          .forEach(job ->
+              this.jobs.add(job.getMemberJobEntity().getName()));
+    }
+  }
+
 }
 

--- a/src/main/java/keeper/project/homepage/admin/service/member/AdminMemberService.java
+++ b/src/main/java/keeper/project/homepage/admin/service/member/AdminMemberService.java
@@ -1,5 +1,6 @@
 package keeper.project.homepage.admin.service.member;
 
+import java.util.ArrayList;
 import java.util.List;
 import keeper.project.homepage.admin.dto.member.MemberDemeritDto;
 import keeper.project.homepage.admin.dto.member.MemberDto;
@@ -22,6 +23,7 @@ import keeper.project.homepage.repository.member.MemberRankRepository;
 import keeper.project.homepage.repository.member.MemberRepository;
 import keeper.project.homepage.repository.member.MemberTypeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,8 +36,16 @@ public class AdminMemberService {
   private final MemberHasMemberJobRepository memberHasMemberJobRepository;
   private final MemberJobRepository memberJobRepository;
 
-  public List<MemberEntity> findAll() {
-    return memberRepository.findAll();
+  public List<MemberDto> getMembers(Pageable pageable) {
+    List<MemberDto> memberDtoList = new ArrayList<>();
+    List<MemberEntity> memberEntityList = memberRepository.findAll(pageable).getContent();
+
+    for(MemberEntity memberEntity : memberEntityList) {
+      MemberDto memberDto = new MemberDto(memberEntity);
+      memberDtoList.add(memberDto);
+    }
+
+    return memberDtoList;
   }
 
   public MemberEntity findByLoginId(String loginId) {

--- a/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
@@ -5,7 +5,6 @@ import javax.servlet.http.HttpServletResponse;
 import keeper.project.homepage.common.dto.sign.EmailAuthDto;
 import keeper.project.homepage.user.dto.member.MemberDto;
 import keeper.project.homepage.user.dto.member.MemberFollowDto;
-import keeper.project.homepage.user.dto.posting.PostingDto;
 import keeper.project.homepage.common.dto.result.CommonResult;
 import keeper.project.homepage.common.dto.result.ListResult;
 import keeper.project.homepage.user.dto.member.OtherMemberInfoResult;
@@ -51,38 +50,28 @@ public class MemberController {
 
   @Secured("ROLE_회원")
   @GetMapping(value = "/members")
-  public ListResult<OtherMemberInfoResult> getAllOtherMemberInfo(
-      @PageableDefault(size = 20, sort = "registerDate", direction = Direction.DESC) Pageable pageable
+  public ListResult<OtherMemberInfoResult> getOtherMembers(
+      @PageableDefault(size = 20, sort = "id", direction = Direction.DESC) Pageable pageable
   ) {
-    return responseService.getSuccessListResult(memberService.getAllOtherMemberInfo(pageable));
+    return responseService.getSuccessListResult(memberService.getOtherMembers(pageable));
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/other-id/{id}")
-  public SingleResult<OtherMemberInfoResult> getOtherMemberInfoById(
+  @GetMapping(value = "/members/{id}")
+  public SingleResult<OtherMemberInfoResult> getOtherMember(
       @PathVariable("id") Long otherMemberId
   ) {
     return responseService.getSuccessSingleResult(
-        memberService.getOtherMemberInfoById(otherMemberId));
+        memberService.getOtherMember(otherMemberId));
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/other-name/{name}")
-  public SingleResult<OtherMemberInfoResult> getOtherMemberInfoByRealName(
-      @PathVariable("name") String realName
-  ) {
-    return responseService.getSuccessSingleResult(
-        memberService.getOtherMemberInfoByRealName(realName));
-  }
-
-  // TODO : 이거 삭제 (테스트 & 문서도)
-  @Secured("ROLE_회원") // 각 리소스별 권한 설정
   @GetMapping(value = "/member")
-  public SingleResult<MemberEntity> findMember() {
+  public SingleResult<MemberDto> getMember() {
     // SecurityContext에서 인증받은 회원의 정보를 얻어온다.
     Long id = authService.getMemberIdByJWT();
     // 결과데이터가 단일건인경우 getSuccessSingleResult 이용해서 결과를 출력한다.
-    return responseService.getSuccessSingleResult(memberService.findById(id));
+    return responseService.getSuccessSingleResult(memberService.getMember(id));
   }
 
   @Secured("ROLE_회원")

--- a/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
@@ -39,7 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Log4j2
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1")
+@RequestMapping(value = "/v1/members")
 public class MemberController {
 
   private final MemberService memberService;
@@ -49,7 +49,7 @@ public class MemberController {
   private final PostingService postingService;
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/members")
+  @GetMapping(value = "/others")
   public ListResult<OtherMemberInfoResult> getOtherMembers(
       @PageableDefault(size = 20, sort = "id", direction = Direction.DESC) Pageable pageable
   ) {
@@ -57,7 +57,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/members/{id}")
+  @GetMapping(value = "/others/{id}")
   public SingleResult<OtherMemberInfoResult> getOtherMember(
       @PathVariable("id") Long otherMemberId
   ) {
@@ -66,7 +66,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member")
+  @GetMapping(value = "")
   public SingleResult<MemberDto> getMember() {
     // SecurityContext에서 인증받은 회원의 정보를 얻어온다.
     Long id = authService.getMemberIdByJWT();
@@ -75,7 +75,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @PutMapping(value = "/member/update/profile")
+  @PutMapping(value = "/profile")
   public SingleResult<MemberDto> updateProfile(@RequestBody MemberDto memberDto) {
     // SecurityContext에서 인증받은 회원의 정보를 얻어온다.
     Long id = authService.getMemberIdByJWT();
@@ -84,7 +84,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @PutMapping(value = "/member/update/thumbnail")
+  @PutMapping(value = "/thumbnail")
   public SingleResult<MemberDto> updateThumbnail(
       @RequestParam("thumbnail") MultipartFile image,
       @RequestParam("ipAddress") String ipAddress) {
@@ -94,7 +94,7 @@ public class MemberController {
     return responseService.getSuccessSingleResult(updated);
   }
 
-  @PostMapping(value = "/member/update/emailauth")
+  @PostMapping(value = "/emailauth")
   public CommonResult emailAuth(@RequestBody EmailAuthDto emailAuthDto) {
     EmailAuthDto emailAuthDtoForSend = memberService.generateEmailAuth(emailAuthDto);
     memberService.sendEmailAuthCode(emailAuthDtoForSend);
@@ -102,7 +102,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @PutMapping(value = "/member/update/email")
+  @PutMapping(value = "/email")
   public SingleResult<MemberDto> updateEmailAddress(@RequestBody MemberDto memberDto) {
     // SecurityContext에서 인증받은 회원의 정보를 얻어온다.
     Long id = authService.getMemberIdByJWT();
@@ -113,7 +113,7 @@ public class MemberController {
 
   // TODO : registerTime 기준으로 정렬이 제대로 안됨.
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/post")
+  @GetMapping(value = "/posts")
   public ListResult<PostingResponseDto> findAllPosting(
       @SortDefault(sort = "registerTime", direction = Direction.DESC)
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
@@ -126,7 +126,7 @@ public class MemberController {
 
   // TODO : registerTime 기준으로 정렬이 제대로 안됨.
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/temp_post")
+  @GetMapping(value = "/temp_posts")
   public ListResult<PostingResponseDto> findAllTempPosting(
       @SortDefault(sort = "registerTime", direction = Direction.DESC)
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
@@ -138,7 +138,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/post/{pid}")
+  @GetMapping(value = "/posts/{pid}")
   public void findPosting(@PathVariable("pid") Long postingId, HttpServletResponse response) {
     String uri = "/v1/post/" + postingId;
     try {
@@ -150,7 +150,7 @@ public class MemberController {
 
   @Secured("ROLE_회원")
   @RequestMapping(method = {RequestMethod.PUT,
-      RequestMethod.PATCH}, value = "/member/post/{pid}")
+      RequestMethod.PATCH}, value = "/posts/{pid}")
   public void modifyPosting(@PathVariable("pid") Long postingId, HttpServletResponse response) {
     String uri = "/v1/post/" + postingId.toString();
     try {
@@ -161,7 +161,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @DeleteMapping(value = "/member/post/{pid}")
+  @DeleteMapping(value = "/posts/{pid}")
   public void deletePosting(@PathVariable("pid") Long postingId, HttpServletResponse response) {
     String uri = "/v1/post/" + postingId.toString();
     try {
@@ -172,7 +172,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @PostMapping(value = "/member/follow")
+  @PostMapping(value = "/follow")
   public CommonResult followByLoginId(@RequestBody MemberDto memberDto) {
     Long id = authService.getMemberIdByJWT();
     memberService.follow(id, memberDto.getFolloweeLoginId());
@@ -180,7 +180,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @DeleteMapping(value = "/member/unfollow")
+  @DeleteMapping(value = "/unfollow")
   public CommonResult unfollowByLoginId(@RequestBody MemberDto memberDto) {
     Long id = authService.getMemberIdByJWT();
     memberService.unfollow(id, memberDto.getFolloweeLoginId());
@@ -188,7 +188,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/follower")
+  @GetMapping(value = "/followers")
   public ListResult<MemberDto> showFollowerList() {
     Long id = authService.getMemberIdByJWT();
     List<MemberDto> followerList = memberService.showFollower(id);
@@ -196,7 +196,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping(value = "/member/followee")
+  @GetMapping(value = "/followees")
   public ListResult<MemberDto> showFolloweeList() {
     Long id = authService.getMemberIdByJWT();
     List<MemberDto> followeeList = memberService.showFollowee(id);
@@ -204,7 +204,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @DeleteMapping("/member/delete")
+  @DeleteMapping("")
   public CommonResult deleteMember(@RequestParam("password") String password) {
     Long id = authService.getMemberIdByJWT();
     memberDeleteService.deleteAccount(id, password);
@@ -212,7 +212,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping("/member/{memberId}/posts")
+  @GetMapping("/{memberId}/posts")
   public ListResult<PostingResponseDto> findPostingListOfOther(
       @PathVariable("memberId") Long memberId,
       @PageableDefault(size = 10, page = 0, sort = "registerTime", direction = Direction.DESC) Pageable pageable
@@ -223,7 +223,7 @@ public class MemberController {
   }
 
   @Secured("ROLE_회원")
-  @GetMapping("/member/{memberId}/posts/{postId}")
+  @GetMapping("/{memberId}/posts/{postId}")
   public SingleResult<PostingResponseDto> findSinglePostingOfOther(
       @PathVariable("memberId") Long memberId,
       @PathVariable("postId") Long postId) {
@@ -233,7 +233,7 @@ public class MemberController {
   }
     
   @Secured("ROLE_회원")
-  @GetMapping("/member/follow-number")
+  @GetMapping("/follow-number")
   public SingleResult<MemberFollowDto> getFollowerAndFolloweeCount() {
     Long id = authService.getMemberIdByJWT();
     MemberFollowDto followDto = memberService.getFollowerAndFolloweeNumber(id);

--- a/src/main/java/keeper/project/homepage/user/dto/member/MemberDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/MemberDto.java
@@ -87,5 +87,39 @@ public class MemberDto {
     }
   }
 
+  public MemberDto(MemberEntity memberEntity) {
+    // 민감한 정보 포함
+    this.id = memberEntity.getId();
+    this.loginId = memberEntity.getLoginId();
+    this.password = null;//memberEntity.getPassword();
+    this.realName = memberEntity.getRealName();
+    this.nickName = memberEntity.getNickName();
+    this.birthday = memberEntity.getBirthday();
+    this.emailAddress = memberEntity.getEmailAddress();
+    this.studentId = memberEntity.getStudentId();
+    this.registerDate = memberEntity.getRegisterDate();
+    this.point = memberEntity.getPoint();
+    this.level = memberEntity.getLevel();
+    this.merit = memberEntity.getMerit();
+    this.demerit = memberEntity.getDemerit();
+    this.generation = memberEntity.getGeneration();
+
+    if (memberEntity.getThumbnail() != null) {
+      this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
+    }
+    if (memberEntity.getMemberRank() != null) {
+      this.rank = memberEntity.getMemberRank().getName();
+    }
+    if (memberEntity.getMemberType() != null) {
+      this.type = memberEntity.getMemberType().getName();
+    }
+    if (memberEntity.getMemberJobs() != null || memberEntity.getMemberJobs().isEmpty() == false) {
+      this.jobs = new ArrayList<>();
+      memberEntity.getMemberJobs()
+          .forEach(job ->
+              this.jobs.add(job.getMemberJobEntity().getName()));
+    }
+  }
+
 }
 

--- a/src/main/java/keeper/project/homepage/user/dto/member/OtherMemberInfoResult.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/OtherMemberInfoResult.java
@@ -1,6 +1,8 @@
 package keeper.project.homepage.user.dto.member;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import keeper.project.homepage.common.controller.util.ImageController;
 import keeper.project.homepage.entity.ThumbnailEntity;
 import keeper.project.homepage.entity.member.MemberEntity;
@@ -15,19 +17,15 @@ import lombok.Setter;
 @AllArgsConstructor
 public class OtherMemberInfoResult {
 
-  private String loginId;
-
-  private String realName;
-
   private String nickName;
 
   private Date birthday;
 
-  private Date registerDate;
+  private String memberType;
 
-  private MemberTypeEntity memberTypeEntity;
+  private String memberRank;
 
-  private MemberRankEntity memberRankEntity;
+  private List<String> memberJobs;
 
   private String thumbnailPath;
 
@@ -38,13 +36,20 @@ public class OtherMemberInfoResult {
   private Boolean checkFollower;
 
   public OtherMemberInfoResult(MemberEntity memberEntity) {
-    this.loginId = memberEntity.getLoginId();
-    this.realName = memberEntity.getRealName();
     this.nickName = memberEntity.getNickName();
     this.birthday = memberEntity.getBirthday();
-    this.registerDate = memberEntity.getRegisterDate();
-    this.memberTypeEntity = memberEntity.getMemberType();
-    this.memberRankEntity = memberEntity.getMemberRank();
+    if(memberEntity.getMemberType() != null) {
+      this.memberType = memberEntity.getMemberType().getName();
+    }
+    if(memberEntity.getMemberRank() != null) {
+      this.memberRank = memberEntity.getMemberRank().getName();
+    }
+    if (memberEntity.getMemberJobs() != null || !memberEntity.getMemberJobs().isEmpty()) {
+      this.memberJobs = new ArrayList<>();
+      memberEntity.getMemberJobs()
+          .forEach(job ->
+              this.memberJobs.add(job.getMemberJobEntity().getName()));
+    }
     if (memberEntity.getThumbnail() != null) {
       this.thumbnailPath = ImageController.THUMBNAIL_PATH + memberEntity.getThumbnail().getId();
     }

--- a/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
+++ b/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
@@ -63,6 +63,13 @@ public class MemberService {
     return memberRepository.findByLoginId(loginId).orElseThrow(CustomMemberNotFoundException::new);
   }
 
+  public MemberDto getMember(Long id) {
+    MemberEntity memberEntity = memberRepository.findById(id)
+        .orElseThrow(CustomMemberNotFoundException::new);
+
+    return new MemberDto(memberEntity);
+  }
+
   private Boolean checkFollowing(MemberEntity other) {
     MemberEntity me = authService.getMemberEntityWithJWT();
     if (me.getFollowee().contains(other) == false) {
@@ -79,33 +86,27 @@ public class MemberService {
     return true;
   }
 
-  public OtherMemberInfoResult getOtherMemberInfoById(Long otherMemberId) {
+  public OtherMemberInfoResult getOtherMember(Long otherMemberId) {
     MemberEntity memberEntity = memberRepository.findById(otherMemberId)
         .orElseThrow(CustomMemberNotFoundException::new);
 
-    OtherMemberInfoResult result = new OtherMemberInfoResult(memberEntity);
-    result.setCheckFollow(checkFollowing(memberEntity), checkFollower(memberEntity));
-    return result;
+    OtherMemberInfoResult otherMemberInfoResult = new OtherMemberInfoResult(memberEntity);
+    otherMemberInfoResult.setCheckFollow(checkFollowing(memberEntity), checkFollower(memberEntity));
+    return otherMemberInfoResult;
   }
 
-  public OtherMemberInfoResult getOtherMemberInfoByRealName(String realName) {
-    MemberEntity memberEntity = memberRepository.findByRealName(realName)
-        .orElseThrow(CustomMemberNotFoundException::new);
+  public List<OtherMemberInfoResult> getOtherMembers(Pageable pageable) {
+    List<OtherMemberInfoResult> otherMemberInfoResultList = new ArrayList<>();
+    List<MemberEntity> memberEntityList = memberRepository.findAll(pageable).getContent();
 
-    OtherMemberInfoResult result = new OtherMemberInfoResult(memberEntity);
-    result.setCheckFollow(checkFollowing(memberEntity), checkFollower(memberEntity));
-    return result;
-  }
+    for (MemberEntity memberEntity : memberEntityList) {
+      OtherMemberInfoResult otherMemberInfoResult = new OtherMemberInfoResult(memberEntity);
+      otherMemberInfoResult.setCheckFollow(checkFollowing(memberEntity),
+          checkFollower(memberEntity));
+      otherMemberInfoResultList.add(otherMemberInfoResult);
+    }
 
-  public List<OtherMemberInfoResult> getAllOtherMemberInfo(Pageable pageable) {
-    return memberRepository.findAll(pageable).stream()
-        .map(member -> {
-          OtherMemberInfoResult other = new OtherMemberInfoResult(member);
-          other.setCheckFollow(checkFollowing(member), checkFollower(member));
-          return other;
-        })
-        .sorted(Comparator.comparing(OtherMemberInfoResult::getRegisterDate).reversed())
-        .collect(Collectors.toList());
+    return otherMemberInfoResultList;
   }
 
   public void follow(Long myId, String followLoginId) {

--- a/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ApiControllerTestHelper.java
@@ -344,17 +344,45 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
     return commonFields;
   }
 
+  public List<FieldDescriptor> generatePrivateMemberCommonResponseFields(ResponseType type,
+      String success, String code, String msg, FieldDescriptor... addDescriptors) {
+    String prefix = type.getReponseFieldPrefix();
+    List<FieldDescriptor> commonFields = new ArrayList<>();
+    commonFields.addAll(generateCommonResponseFields(success, code, msg));
+    commonFields.addAll(Arrays.asList(
+        fieldWithPath(prefix + ".id").description("아이디"),
+        fieldWithPath(prefix + ".loginId").description("로그인 아이디"),
+        fieldWithPath(prefix + ".emailAddress").description("이메일 주소"),
+        fieldWithPath(prefix + ".realName").description("실제 이름"),
+        fieldWithPath(prefix + ".nickName").description("닉네임"),
+        fieldWithPath(prefix + ".birthday").description("생일").type(Date.class).optional(),
+        fieldWithPath(prefix + ".registerDate").description("학"),
+        fieldWithPath(prefix + ".studentId").description("가입 날짜"),
+        fieldWithPath(prefix + ".point").description("포인트 점수"),
+        fieldWithPath(prefix + ".level").description("레벨"),
+        fieldWithPath(prefix + ".merit").description("상점"),
+        fieldWithPath(prefix + ".demerit").description("벌점"),
+        fieldWithPath(prefix + ".generation").description("기수 (7월 이후는 N.5기)"),
+        fieldWithPath(prefix + ".thumbnailPath").description("회원의 썸네일 이미지 조회 api path"),
+        fieldWithPath(prefix + ".rank").description("회원 등급: null, 우수회원, 일반회원"),
+        fieldWithPath(prefix + ".type").description("회원 상태: null, 비회원, 정회원, 휴면회원, 졸업회원, 탈퇴"),
+        fieldWithPath(prefix + ".jobs").description(
+            "동아리 직책: null, ROLE_회장, ROLE_부회장, ROLE_대외부장, ROLE_학술부장, ROLE_전산관리자, ROLE_서기, ROLE_총무, ROLE_사서"))
+    );
+    if (addDescriptors.length > 0) {
+      commonFields.addAll(Arrays.asList(addDescriptors));
+    }
+    return commonFields;
+  }
+
   public List<FieldDescriptor> generateOtherMemberInfoCommonResponseFields(ResponseType type,
       String success, String code, String msg, FieldDescriptor... addDescriptors) {
     String prefix = type.getReponseFieldPrefix();
     List<FieldDescriptor> commonFields = new ArrayList<>();
     commonFields.addAll(generateCommonResponseFields(success, code, msg));
     commonFields.addAll(Arrays.asList(
-        fieldWithPath(prefix + ".loginId").description("해당 유저의 로그인 아이디"),
-        fieldWithPath(prefix + ".realName").description("해당 유저의 실제 이름"),
         fieldWithPath(prefix + ".nickName").description("해당 유저의 닉네임"),
         fieldWithPath(prefix + ".birthday").description("해당 유저의 생일").type(Date.class).optional(),
-        fieldWithPath(prefix + ".registerDate").description("해당 유저의 회원가입 날짜 및 시간"),
         fieldWithPath(prefix + ".checkFollowee").description(
             "상대방을 팔로우 했는지 확인(팔로우: true, 아니면: false)"),
         fieldWithPath(prefix + ".checkFollower").description(
@@ -362,10 +390,10 @@ public class ApiControllerTestHelper extends ApiControllerTestSetUp {
         fieldWithPath(prefix + ".generation").description("기수 (7월 이후는 N.5기)").optional(),
         fieldWithPath(prefix + ".thumbnailPath").description("해당 유저의 썸네일 이미지 조회 api path")
             .optional(),
-        subsectionWithPath(prefix + ".memberRankEntity").description(
-            "해당 유저의 등급(id): 일반회원(1), 우수회원(2)").optional(),
-        subsectionWithPath(prefix + ".memberTypeEntity").description(
-            "해당 유저의 유형(id): 비회원(1), 정회원(2), 휴면회원(3), 졸업(4), 탈퇴(5)").optional()
+        subsectionWithPath(prefix + ".memberRank").description("회원 등급: null, 우수회원, 일반회원"),
+        subsectionWithPath(prefix + ".memberType").description("회원 상태: null, 비회원, 정회원, 휴면회원, 졸업회원, 탈퇴"),
+        subsectionWithPath(prefix + ".memberJobs").description(
+            "동아리 직책: null, ROLE_회장, ROLE_부회장, ROLE_대외부장, ROLE_학술부장, ROLE_전산관리자, ROLE_서기, ROLE_총무, ROLE_사서")
     ));
     if (addDescriptors.length > 0) {
       commonFields.addAll(Arrays.asList(addDescriptors));

--- a/src/test/java/keeper/project/homepage/admin/controller/member/AdminMemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/admin/controller/member/AdminMemberControllerTest.java
@@ -1,0 +1,73 @@
+package keeper.project.homepage.admin.controller.member;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import keeper.project.homepage.ApiControllerTestHelper;
+import keeper.project.homepage.entity.member.MemberEntity;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Log4j2
+public class AdminMemberControllerTest extends ApiControllerTestHelper {
+
+  private MemberEntity userEntity;
+  private MemberEntity adminEntity;
+
+  private String userToken;
+  private String adminToken;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    userEntity = generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원, MemberRankName.일반회원);
+    userToken = generateJWTToken(userEntity);
+    adminEntity = generateMemberEntity(MemberJobName.회장, MemberTypeName.정회원, MemberRankName.우수회원);
+    adminToken = generateJWTToken(adminEntity);
+    for (int i = 0; i < 22; i++) {
+      generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원, MemberRankName.일반회원);
+    }
+  }
+
+  @Test
+  @DisplayName("관리자 권한으로 회원 정보 목록 조회 - 성공")
+  public void getMembersSuccess() throws Exception {
+    mockMvc.perform(get("/v1/admin/members")
+            .header("Authorization", adminToken)
+            .param("page", "0")
+            .param("size", "20"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andDo(document("admin-members",
+            requestParameters(
+                parameterWithName("page").optional().description("페이지 번호(default = 0)"),
+                parameterWithName("size").optional().description("한 페이지당 출력 수(default = 20)")
+            ),
+            responseFields(
+                generatePrivateMemberCommonResponseFields(ResponseType.LIST,
+                    "성공: true +\n실패: false", "성공 시 0을 반환", "성공: 성공하였습니다 +\n실패: 에러 메세지 반환")
+            )));
+  }
+
+  @Test
+  @DisplayName("관리자 권한으로 회원 정보 목록 조회 - 실패(권한 부족)")
+  public void getMembersFailByAuth() throws Exception {
+    mockMvc.perform(get("/v1/admin/members")
+            .header("Authorization", userToken)
+            .param("page", "0")
+            .param("size", "20"))
+        .andDo(print())
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.msg").value("보유한 권한으로 접근할수 없는 리소스 입니다"));
+  }
+
+}

--- a/src/test/java/keeper/project/homepage/controller/member/MemberControllerFindPostingTest.java
+++ b/src/test/java/keeper/project/homepage/controller/member/MemberControllerFindPostingTest.java
@@ -70,7 +70,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
   public void findAllPostingById() throws Exception {
     String docMsg = "실패할 경우 알 수 없는 오류가 발생하였습니다 문구가 뜹니다.";
     String docCode = "에러가 발생할 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(get("/v1/member/post")
+    mockMvc.perform(get("/v1/members/posts")
             .header("Authorization", userToken)
             .param("page", "0")
             .param("size", "10"))
@@ -97,7 +97,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
   public void findAllTempPostingById() throws Exception {
     String docMsg = "실패할 경우 알 수 없는 오류가 발생하였습니다 문구가 뜹니다.";
     String docCode = "에러가 발생할 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(get("/v1/member/temp_post")
+    mockMvc.perform(get("/v1/members/temp_posts")
             .header("Authorization", userToken)
             .param("page", "0")
             .param("size", "10"))
@@ -121,7 +121,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
   @DisplayName("자신이 작성한 게시글 하나 조회하기")
   public void findPostingRedirect() throws Exception {
     Long postId = tempPosting.getId();
-    mockMvc.perform(get("/v1/member/post/{pid}", postId)
+    mockMvc.perform(get("/v1/members/posts/{pid}", postId)
             .header("Authorization", userToken)
         )
         .andDo(print())
@@ -154,7 +154,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
   @DisplayName("자신이 작성한 게시글 수정하기")
   public void updatePostingRedirect() throws Exception {
     Long postId = tempPosting.getId();
-    mockMvc.perform(put("/v1/member/post/{pid}", postId)
+    mockMvc.perform(put("/v1/members/posts/{pid}", postId)
             .header("Authorization", userToken)
         )
         .andDo(print())
@@ -170,7 +170,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
   @DisplayName("자신이 작성한 게시글 삭제하기")
   public void deletePostingRedirect() throws Exception {
     Long postId = tempPosting.getId();
-    mockMvc.perform(delete("/v1/member/post/{pid}", postId)
+    mockMvc.perform(delete("/v1/members/posts/{pid}", postId)
             .header("Authorization", userToken)
         )
         .andDo(print())
@@ -197,7 +197,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
     String docMsg = "(나중에 예외 사항을 추가하겠습니다..!)"
         + " +\n" + "그 외 실패한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     Long otherId = memberEntity2.getId();
-    mockMvc.perform(get("/v1/member/{memberId}/posts", otherId)
+    mockMvc.perform(get("/v1/members/{memberId}/posts", otherId)
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(jsonPath("$.list.length()", greaterThan(0)))
@@ -229,7 +229,7 @@ public class MemberControllerFindPostingTest extends ApiControllerTestHelper {
         + " +\n" + "그 외 실패한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     Long otherId = memberEntity2.getId();
     Long postId = posting.getId();
-    mockMvc.perform(get("/v1/member/{memberId}/posts/{postId}", otherId, postId)
+    mockMvc.perform(get("/v1/members/{memberId}/posts/{postId}", otherId, postId)
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())

--- a/src/test/java/keeper/project/homepage/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/member/MemberControllerTest.java
@@ -50,7 +50,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
   @Test
   @DisplayName("잘못된 토큰으로 접근하기")
   public void invalidToken() throws Exception {
-    mockMvc.perform(get("/v1/member")
+    mockMvc.perform(get("/v1/members")
             .header("Authorization", "XXXXXXXXXX"))
         .andDo(print())
         .andExpect(jsonPath("$.success").value(false))
@@ -60,7 +60,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
   @Test
   @DisplayName("토큰 없이 접근하기")
   public void noToken() throws Exception {
-    mockMvc.perform(get("/v1/member"))
+    mockMvc.perform(get("/v1/members"))
         .andDo(print())
         .andExpect(jsonPath("$.success").value(false));
 //        .andExpect(jsonPath("$.code").value(-1002));
@@ -69,7 +69,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
   @Test
   @DisplayName("옳은 토큰으로 접근하기")
   public void validToken() throws Exception {
-    mockMvc.perform(get("/v1/member")
+    mockMvc.perform(get("/v1/members")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk());
@@ -114,7 +114,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
   @DisplayName("기본 권한으로 본인 정보 열람하기")
   public void findMember() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .get("/v1/member")
+            .get("/v1/members")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
@@ -131,7 +131,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
     String docMsg = "팔로우할 회원이 존재하지 않는다면 실패합니다.";
     String docCode = "회원이 존재하지 않을 경우: " + exceptionAdvice.getMessage("memberNotFound.code") + " +\n"
         + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(MockMvcRequestBuilders.post("/v1/member/follow")
+    mockMvc.perform(MockMvcRequestBuilders.post("/v1/members/follow")
             .header("Authorization", userToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -167,7 +167,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
     String docMsg = "언팔로우할 회원이 존재하지 않는다면 실패합니다.";
     String docCode = "회원이 존재하지 않을 경우: " + exceptionAdvice.getMessage("memberNotFound.code") + " +\n"
         + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(MockMvcRequestBuilders.delete("/v1/member/unfollow")
+    mockMvc.perform(MockMvcRequestBuilders.delete("/v1/members/unfollow")
             .header("Authorization", userToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -195,7 +195,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
 
     String docMsg = "";
     String docCode = "에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(get("/v1/member/followee")
+    mockMvc.perform(get("/v1/members/followees")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
@@ -217,7 +217,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
 
     String docMsg = "";
     String docCode = "에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(get("/v1/member/follower")
+    mockMvc.perform(get("/v1/members/followers")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
@@ -231,48 +231,13 @@ public class MemberControllerTest extends MemberControllerTestSetup {
   }
 
   @Test
-  @DisplayName("회원 정보 조회(민감한 정보 제외) - 성공")
-  public void getAllGeneralMemberInfoSuccess() throws Exception {
-    String docCode = "에러 발생 시: " + exceptionAdvice.getMessage("unKnown.code");
-    String docMsg = "민감한 정보를 제외한 다른 회원의 정보를 조회합니다. 한 페이지 당 최대 개수는 20개 입니다.";
-    mockMvc.perform(MockMvcRequestBuilders
-            .get("/v1/members")
-            .param("page", "0")
-            .header("Authorization", userToken))
-        .andDo(print())
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.success").value(true))
-        .andDo(document("members-show",
-            requestParameters(
-                parameterWithName("page").description("페이지 번호")
-            ),
-            responseFields(
-                generateOtherMemberInfoCommonResponseFields(ResponseType.LIST,
-                    "성공: true +\n실패: false", docCode, docMsg)
-            )
-        ));
-  }
-
-  @Test
-  @DisplayName("회원 정보 조회(민감한 정보 제외) - 실패(회원 권한 X)")
-  public void getAllGeneralMemberInfoFail() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders
-            .get("/v1/members")
-            .header("Authorization", 1234))
-        .andDo(print())
-        .andExpect(status().is4xxClientError())
-        .andExpect(jsonPath("$.success").value(false))
-        .andExpect(jsonPath("$.msg").value("보유한 권한으로 접근할수 없는 리소스 입니다"));
-  }
-
-  @Test
   @DisplayName("회원 탈퇴하기")
   public void deleteAccount() throws Exception {
     String docMsg = "물품을 대여하고 미납한 기록이 남아있을 경우, 또는 입력한 비밀번호가 옳지 않은 경우 탈퇴가 실패합니다.";
     String docCode =
         "물품 미납 기록이 있거나 비밀번호가 틀린 경우: " + exceptionAdvice.getMessage("accountDeleteFailed.code")
             + " +\n" + "그 외 실패한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(delete("/v1/member/delete")
+    mockMvc.perform(delete("/v1/members")
             .param("password", memberPassword)
             .header("Authorization", userToken))
         .andDo(print())
@@ -310,7 +275,7 @@ public class MemberControllerTest extends MemberControllerTestSetup {
     // TODO : 예외 처리 & doc 메세지 채우기 (회원 관리 전체적으로 예외 수정할 예정)
     String docMsg = "";
     String docCode = "실패한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(get("/v1/member/follow-number")
+    mockMvc.perform(get("/v1/members/follow-number")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())

--- a/src/test/java/keeper/project/homepage/controller/member/MemberUpdateControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/member/MemberUpdateControllerTest.java
@@ -227,7 +227,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             + "존재하지 않는 회원인 경우: " + exceptionAdvice.getMessage("memberNotFound.code") + " +\n"
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/admin/member/update/generation")
+            .put("/v1/admin/members/generation")
             .header("Authorization", adminToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -262,7 +262,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             + "입력한 rank가 존재하지 않는 경우: " + exceptionAdvice.getMessage("memberInfoNotFound.code")
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/admin/member/update/rank")
+            .put("/v1/admin/members/rank")
             .header("Authorization", adminToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -301,7 +301,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             + "입력한 type이 존재하지 않는 경우: " + exceptionAdvice.getMessage("memberInfoNotFound.code")
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/admin/member/update/type")
+            .put("/v1/admin/members/type")
             .header("Authorization", adminToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -342,7 +342,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             + "입력한 job이 존재하지 않는 경우: " + exceptionAdvice.getMessage("memberInfoNotFound.code")
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/admin/member/update/job")
+            .put("/v1/admin/members/job")
             .header("Authorization", adminToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -391,7 +391,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             + "존재하지 않는 회원인 경우: " + exceptionAdvice.getMessage("memberNotFound.code") + " +\n"
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/member/update/profile")
+            .put("/v1/members/profile")
             .header("Authorization", userToken)
             .content(updateContent)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -425,7 +425,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
         + "}";
 
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/member/update/profile")
+            .put("/v1/members/profile")
             .header("Authorization", userToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -456,7 +456,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             "entryPointException.code") + " +\n"
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/member/update/email")
+            .put("/v1/members/email")
             .header("Authorization", userToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -488,7 +488,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
         + "}";
 
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/member/update/email")
+            .put("/v1/members/email")
             .header("Authorization", userToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -510,7 +510,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
         + "}";
 
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/v1/member/update/email")
+            .put("/v1/members/email")
             .header("Authorization", userToken)
             .content(content)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -548,7 +548,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
             + " +\n"
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
     // @formatter:on
-    mockMvc.perform(RestDocumentationRequestBuilders.fileUpload("/v1/member/update/thumbnail")
+    mockMvc.perform(RestDocumentationRequestBuilders.fileUpload("/v1/members/thumbnail")
             .file(image)
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .param("ipAddress", "111.111.111.111")
@@ -588,7 +588,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
         "입력 데이터가 비어있는 경우: " + exceptionAdvice.getMessage("memberEmptyField.code") + " +\n"
             + "존재하지 않는 회원인 경우: " + exceptionAdvice.getMessage("memberNotFound.code") + " +\n"
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(MockMvcRequestBuilders.put("/v1/admin/member/update/merit")
+    mockMvc.perform(MockMvcRequestBuilders.put("/v1/admin/members/merit")
             .header("Authorization", adminToken)
             .content(updateContent)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -619,7 +619,7 @@ public class MemberUpdateControllerTest extends MemberControllerTestSetup {
         "입력 데이터가 비어있는 경우: " + exceptionAdvice.getMessage("memberEmptyField.code") + " +\n"
             + "존재하지 않는 회원인 경우: " + exceptionAdvice.getMessage("memberNotFound.code") + " +\n"
             + " +\n" + "그 외 에러가 발생한 경우: " + exceptionAdvice.getMessage("unKnown.code");
-    mockMvc.perform(MockMvcRequestBuilders.put("/v1/admin/member/update/demerit")
+    mockMvc.perform(MockMvcRequestBuilders.put("/v1/admin/members/demerit")
             .header("Authorization", adminToken)
             .content(updateContent)
             .contentType(MediaType.APPLICATION_JSON_VALUE))

--- a/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
@@ -44,7 +44,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 정보 리스트 조회하기 - 성공")
   public void getAllOtherUserInfoSuccess() throws Exception {
-    mockMvc.perform(get("/v1/members")
+    mockMvc.perform(get("/v1/members/others")
             .param("page", "0")
             .param("size", "20")
             .header("Authorization", userToken))
@@ -64,7 +64,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 정보 리스트 조회하기 - 실패(유효하지 않은 토큰)")
   public void getAllOtherUserInfoFail() throws Exception {
-    mockMvc.perform(get("/v1/members")
+    mockMvc.perform(get("/v1/members/others")
             .param("page", "0")
             .param("size", "10")
             .header("Authorization", 111111))
@@ -77,7 +77,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 ID를 통해 정보 조회하기 - 성공")
   public void getOtherUserInfoByIdSuccess() throws Exception {
-    mockMvc.perform(get("/v1/members/{id}", adminEntity.getId())
+    mockMvc.perform(get("/v1/members/others/{id}", adminEntity.getId())
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
@@ -94,7 +94,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 ID를 통해 정보 조회하기 - 실패(유효하지 않은 토큰)")
   public void getOtherUserInfoByIdFailByToken() throws Exception {
-    mockMvc.perform(get("/v1/members/{id}", adminEntity.getId())
+    mockMvc.perform(get("/v1/members/others/{id}", adminEntity.getId())
             .header("Authorization", 111111))
         .andDo(print())
         .andExpect(status().is4xxClientError())
@@ -105,7 +105,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 ID를 통해 정보 조회하기 - 실패(존재하지 않는 ID)")
   public void getOtherUserInfoByIdFailById() throws Exception {
-    mockMvc.perform(get("/v1/members/{id}", 1234567)
+    mockMvc.perform(get("/v1/members/others/{id}", 1234567)
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().is5xxServerError())
@@ -116,7 +116,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("내 정보 조회하기 - 성공")
   public void getMemberSuccess() throws Exception {
-    mockMvc.perform(get("/v1/member")
+    mockMvc.perform(get("/v1/members")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
@@ -130,7 +130,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("내 정보 조회하기 - 실패(권한 에러)")
   public void getMemberFailByAuth() throws Exception {
-    mockMvc.perform(get("/v1/member")
+    mockMvc.perform(get("/v1/members")
             .header("Authorization", 1234))
         .andDo(print())
         .andExpect(status().is4xxClientError())

--- a/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
@@ -77,7 +77,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 ID를 통해 정보 조회하기 - 성공")
   public void getOtherUserInfoByIdSuccess() throws Exception {
-    mockMvc.perform(get("/v1/member/other-id/{id}", adminEntity.getId())
+    mockMvc.perform(get("/v1/members/{id}", adminEntity.getId())
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
@@ -94,7 +94,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 ID를 통해 정보 조회하기 - 실패(유효하지 않은 토큰)")
   public void getOtherUserInfoByIdFailByToken() throws Exception {
-    mockMvc.perform(get("/v1/member/other-id/{id}", adminEntity.getId())
+    mockMvc.perform(get("/v1/members/{id}", adminEntity.getId())
             .header("Authorization", 111111))
         .andDo(print())
         .andExpect(status().is4xxClientError())
@@ -105,7 +105,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @Test
   @DisplayName("다른 유저 ID를 통해 정보 조회하기 - 실패(존재하지 않는 ID)")
   public void getOtherUserInfoByIdFailById() throws Exception {
-    mockMvc.perform(get("/v1/member/other-id/{id}", 1234567)
+    mockMvc.perform(get("/v1/members/{id}", 1234567)
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().is5xxServerError())
@@ -114,33 +114,26 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   }
 
   @Test
-  @DisplayName("다른 유저 실제 이름을 통해 정보 조회하기 - 성공")
-  public void getOtherUserInfoByRealNameSuccess() throws Exception {
-    mockMvc.perform(get("/v1/member/other-name/{name}", adminEntity.getRealName())
+  @DisplayName("내 정보 조회하기 - 성공")
+  public void getMemberSuccess() throws Exception {
+    mockMvc.perform(get("/v1/member")
             .header("Authorization", userToken))
         .andDo(print())
         .andExpect(status().isOk())
-        .andDo(document("member-otherInfo-ByRealName",
-            pathParameters(
-                parameterWithName("name").description("찾고자 하는 다른 유저의 실제 이름")
-            ),
+        .andDo(document("member-info",
             responseFields(
-                generateOtherMemberInfoCommonResponseFields(ResponseType.SINGLE,
+                generatePrivateMemberCommonResponseFields(ResponseType.SINGLE,
                     "성공: true +\n실패: false", "성공 시 0을 반환", "성공: 성공하였습니다 +\n실패: 에러 메세지 반환")
             )));
-
   }
 
   @Test
-  @DisplayName("다른 유저 실제 이름을 통해 정보 조회하기 - 실패(존재하지 않는 이름)")
-  public void getOtherUserInfoByRealNameFailByName() throws Exception {
-    mockMvc.perform(get("/v1/member/other-name/{name}", "없는 이름")
-            .header("Authorization", userToken))
+  @DisplayName("내 정보 조회하기 - 실패(권한 에러)")
+  public void getMemberFailByAuth() throws Exception {
+    mockMvc.perform(get("/v1/member")
+            .header("Authorization", 1234))
         .andDo(print())
-        .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.success").value(false))
-        .andExpect(jsonPath("$.msg").value("존재하지 않는 회원입니다."));
-
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.msg").value("보유한 권한으로 접근할수 없는 리소스 입니다"));
   }
-
 }


### PR DESCRIPTION
## 연관 issue
내용을 적어주세요.
close #187

## 프론트 전달사항
**URL 변경사항**
- 대대적인 변화가 발생했습니다.. 😥
- 행위를 URL에서 제외시키고 HTTP 메소드로 구분
<br>

- 내 정보 조회 `GET` `/v1/members`
- 내 정보 삭제 `DELETE` `/v1/members`
- 다른 회원 일반적 정보 목록 조회 `GET` `/v1/members/others`
- 다른 회원 일반적 정보 조회 `GET` `/v1/members/others/{id}`
- 내 프로필 업데이트 `PUT` `/v1/members/profile`
- 내 썸네일 업데이트 `PUT` `/v1/members/thumbnail`
- 내 이메일 업데이트 `PUT` `/v1/members/email`
- 내가 작성한 게시글 목록 조회 `GET` `/v1/members/posts`
- 내가 작성한 임시 게시글 목록 조회 `GET` `/v1/members/temp_posts`
- 내가 작성한 게시글 조회 `GET` `/v1/members/posts/{pid}`
- 내가 작성한 게시글 수정 `PUT, PATCH` `/v1/members/posts/{pid}`
- 내가 작성한 게시글 삭제 `DELETE` `/v1/members/posts/{pid}`
- 팔로우하기 `POST` `/v1/members/follow`
- 언팔로우하기 `DELETE` `/v1/members/unfollow`
- Follower 목록 조회 `GET` `/v1/members/followers`
- Followee 목록 조회 `GET` `/v1/members/followees`
- 팔로워 숫자 조회 `GET` `/v1/members/follow-number`
- 다른 사람이 작성한 게시글 목록 확인 `GET` `/v1/members/{memberId}/posts`
- 다른 사람이 작성한 게시글 확인 `GET` `/v1/members/{memberId}/posts/{pid}`
<br>

- 관리자 권한으로 다른 회원 정보 목록 조회 `GET` `/v1/admin/members`
- 관리자 권한으로 멤버 Rank 업데이트 `PUT` `/v1/admin/members/rank`
- 관리자 권한으로 멤버 Type 업데이트 `PUT` `/v1/admin/members/type`
- 관리자 권한으로 멤버 Job 업데이트 `PUT` `/v1/admin/members/job`
- 관리자 권한으로 멤버 상점 업데이트 `PUT` `/v1/admin/members/merit`
- 관리자 권한으로 멤버 벌점 업데이트 `PUT` `/v1/admin/members/demerit`

**요청사항 반영**
- 다른 회원 일반적 정보 조회 시 필요하지 않은 데이터는 삭제되었습니다.
- 내 정보 조회하는 API 문서가 추가되었습니다.
- 관리자 권한으로 다른 회원 정보를 조회할 때는 민감한 정보들도 포함되었습니다.