### PR TITLE
Feature/#240 페이지블럭 서브타이틀 버그

### DIFF
--- a/src/main/java/keeper/project/homepage/admin/dto/etc/StaticWriteSubtitleImageResult.java
+++ b/src/main/java/keeper/project/homepage/admin/dto/etc/StaticWriteSubtitleImageResult.java
@@ -33,10 +33,10 @@ public class StaticWriteSubtitleImageResult {
     this.id = staticWriteSubtitleImageEntity.getId();
     this.subtitle = staticWriteSubtitleImageEntity.getSubtitle();
     this.staticWriteTitleId = staticWriteSubtitleImageEntity.getStaticWriteTitle().getId();
-    if(staticWriteSubtitleImageEntity.getThumbnail() != null) {
-      this.thumbnailPath =
-          ImageController.THUMBNAIL_PATH + staticWriteSubtitleImageEntity.getThumbnail().getId();
-    }
+    this.thumbnailPath =
+        staticWriteSubtitleImageEntity.getThumbnail() == null ? ImageController.THUMBNAIL_PATH + 1
+            : ImageController.THUMBNAIL_PATH + staticWriteSubtitleImageEntity.getThumbnail()
+                .getId();
     this.displayOrder = staticWriteSubtitleImageEntity.getDisplayOrder();
     if (staticWriteSubtitleImageEntity.getStaticWriteContents() != null) {
       this.staticWriteContentResults = staticWriteSubtitleImageEntity.getStaticWriteContents()

--- a/src/main/java/keeper/project/homepage/admin/dto/etc/StaticWriteSubtitleImageResult.java
+++ b/src/main/java/keeper/project/homepage/admin/dto/etc/StaticWriteSubtitleImageResult.java
@@ -33,8 +33,10 @@ public class StaticWriteSubtitleImageResult {
     this.id = staticWriteSubtitleImageEntity.getId();
     this.subtitle = staticWriteSubtitleImageEntity.getSubtitle();
     this.staticWriteTitleId = staticWriteSubtitleImageEntity.getStaticWriteTitle().getId();
-    this.thumbnailPath =
-        ImageController.THUMBNAIL_PATH + staticWriteSubtitleImageEntity.getThumbnail().getId();
+    if(staticWriteSubtitleImageEntity.getThumbnail() != null) {
+      this.thumbnailPath =
+          ImageController.THUMBNAIL_PATH + staticWriteSubtitleImageEntity.getThumbnail().getId();
+    }
     this.displayOrder = staticWriteSubtitleImageEntity.getDisplayOrder();
     if (staticWriteSubtitleImageEntity.getStaticWriteContents() != null) {
       this.staticWriteContentResults = staticWriteSubtitleImageEntity.getStaticWriteContents()

--- a/src/test/java/keeper/project/homepage/user/controller/about/AboutTitleControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/about/AboutTitleControllerTest.java
@@ -98,7 +98,6 @@ public class AboutTitleControllerTest extends ApiControllerTestHelper {
     staticWriteContentRepository.save(staticWriteContent);
   }
 
-  /* FIXME 우창
   @Test
   @DisplayName("페이지 블럭 타이틀 타입으로 불러오기 - 성공")
   public void findAllByTypeSuccess() throws Exception {
@@ -120,8 +119,6 @@ public class AboutTitleControllerTest extends ApiControllerTestHelper {
                 subsectionWithPath("list[].subtitleImageResults[]").description("페이지 블럭 타이틀과 연결된 페이지 블럭 서브 타이틀 데이터 리스트")
             )));
   }
-
-   */
 
   @Test
   @DisplayName("페이지 블럭 타이틀 타입으로 불러오기 - 실패(존재하지 않는 타입)")


### PR DESCRIPTION
## 연관 issue
내용을 적어주세요.
close #240

## 프론트 전달사항
- `null` 값을 확인하지 않아 발생하던 오류 수정 완료
- 썸네일이 존재하지 않는 경우 `null`이 아닌 `default 직사각형` 이미지 경로를 반환
=> 페이지 블럭에서는 정사각형 이미지보다는 직사각형 이미지를 사용할 것으로 생각했는데 맞을까요 ?