### PR TITLE
Feature/#252 게시물 수정 로직 변경

### DIFF
--- a/src/docs/asciidoc/posting.adoc
+++ b/src/docs/asciidoc/posting.adoc
@@ -249,6 +249,29 @@ include::{snippets}/post-modify/http-response.adoc[]
 
 include::{snippets}/post-modify/response-body.adoc[]
 
+== 게시글 첨부파일 삭제
+
+=== 요청
+
+==== Request
+
+include::{snippets}/post-file-delete/request-body.adoc[]
+
+==== Request Path Parameters
+
+include::{snippets}/post-file-delete/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/post-file-delete/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/post-file-delete/response-body.adoc[]
+
+
 == 게시글 삭제
 
 === 요청

--- a/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
@@ -190,10 +190,16 @@ public class PostingController {
     ThumbnailEntity newThumbnail = saveThumbnail(thumbnail, dto);
 
     PostingEntity postingEntity = postingService.updateById(dto, postingId, newThumbnail);
-    deletePrevFiles(postingId);
     fileService.saveFiles(files, dto.getIpAddress(), postingEntity);
 
     deletePrevThumbnail(dto);
+
+    return responseService.getSuccessResult();
+  }
+
+  @GetMapping(value = "/delete/{fileId}")
+  public CommonResult deleteFile(@PathVariable("fileId") Long fileId){
+    fileService.deleteFileById(fileId);
 
     return responseService.getSuccessResult();
   }
@@ -202,10 +208,6 @@ public class PostingController {
     List<FileEntity> fileEntities = fileService.findFileEntitiesByPostingId(
         postingEntity);
     fileService.deleteFiles(fileEntities);
-  }
-
-  private void deletePrevFiles(Long postingId) {
-    deletePrevFiles(postingService.getPostingById(postingId));
   }
 
   private ThumbnailEntity saveThumbnail(MultipartFile thumbnail, PostingDto dto) {

--- a/src/main/java/keeper/project/homepage/user/dto/posting/PostingResponseDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/posting/PostingResponseDto.java
@@ -72,7 +72,7 @@ public class PostingResponseDto {
         .isTemp(postingEntity.getIsTemp())
         .category(postingEntity.getCategoryId().getName())
         .categoryId(postingEntity.getCategoryId().getId())
-        .files(postingEntity.getFiles())
+        .files(isOne ? postingEntity.getFiles() : null)
         .thumbnailPath(null)
         .build();
 

--- a/src/main/java/keeper/project/homepage/util/service/FileService.java
+++ b/src/main/java/keeper/project/homepage/util/service/FileService.java
@@ -133,6 +133,20 @@ public class FileService {
     fileRepository.deleteById(deleteId);
   }
 
+  public void deleteFileById(Long deleteId) {
+    FileEntity deletedFileEntity = fileRepository.findById(deleteId)
+        .orElseThrow(CustomFileEntityNotFoundException::new);
+    File deleteFile = new File(
+        System.getProperty("user.dir") + File.separator + deletedFileEntity.getFilePath());
+    if (deleteFile.exists() == false) {
+      throw new CustomFileNotFoundException();
+    }
+    if (deleteFile.delete() == false) {
+      throw new CustomFileDeleteFailedException();
+    }
+    deleteFileEntityById(deleteId);
+  }
+
   // TODO : thumbnail delete와 합치기
   public void deleteOriginalThumbnail(ThumbnailEntity deleteThumbnail) {
     // 기본 썸네일이면 삭제 X

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -683,6 +683,26 @@ public class PostingControllerTest extends ApiControllerTestHelper {
   }
 
   @Test
+  @DisplayName("파일 삭제")
+  public void deleteFile() throws Exception {
+    ResultActions result = mockMvc.perform(
+        RestDocumentationRequestBuilders.get("/v1/post/delete/{fileId}", generalImageFile.getId().toString())
+            .header("Authorization", userToken));
+
+    result.andExpect(MockMvcResultMatchers.status().isOk())
+        .andDo(print())
+        .andDo(document("post-file-delete",
+            pathParameters(
+                parameterWithName("fileId").description("삭제할 파일 ID")
+            ), responseFields(
+                fieldWithPath("success").description("성공: true +\n실패: false"),
+                fieldWithPath("msg").description(""),
+                fieldWithPath("code").description("성공 : 0")
+            )
+        ));
+  }
+
+  @Test
   @DisplayName("게시글 삭제")
   public void deletePosting() throws Exception {
     ResultActions result = mockMvc.perform(

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -232,7 +232,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional()
+                    .optional().type(JsonFieldType.ARRAY)
             )
         ));
   }
@@ -285,7 +285,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional()
+                    .optional().type(JsonFieldType.ARRAY)
             )
         ));
   }
@@ -333,7 +333,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional()
+                    .optional().type(JsonFieldType.ARRAY)
             )
         ));
   }
@@ -751,7 +751,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
   public void searchPosting() throws Exception {
     ResultActions result = mockMvc.perform(get("/v1/post/search")
         .param("type", "T")
-        .param("keyword", "2")
+        .param("keyword", postingGeneralTest.getTitle())
         .param("page", "0")
         .param("size", "5")
         .param("category", categoryEntity.getId().toString())
@@ -797,7 +797,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].size").description("총 게시물 수"),
                 subsectionWithPath("list[].files").description(
                         "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional()
+                    .optional().type(JsonFieldType.ARRAY)
             )
         ));
   }

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -40,6 +40,7 @@ import keeper.project.homepage.entity.ThumbnailEntity;
 import keeper.project.homepage.entity.member.MemberEntity;
 import keeper.project.homepage.user.service.posting.PostingService;
 import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -229,10 +230,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].isNotice").description("공지글?"),
                 fieldWithPath("list[].isSecret").description("비밀글?"),
                 fieldWithPath("list[].isTemp").description("임시저장?"),
-                fieldWithPath("list[].size").description("총 게시물 수"),
-                subsectionWithPath("list[].files").description(
-                        "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional().type(JsonFieldType.ARRAY)
+                fieldWithPath("list[].size").description("총 게시물 수")
             )
         ));
   }
@@ -282,10 +280,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].isNotice").description("공지글?"),
                 fieldWithPath("list[].isSecret").description("비밀글?"),
                 fieldWithPath("list[].isTemp").description("임시저장?"),
-                fieldWithPath("list[].size").description("총 게시물 수"),
-                subsectionWithPath("list[].files").description(
-                        "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional().type(JsonFieldType.ARRAY)
+                fieldWithPath("list[].size").description("총 게시물 수")
             )
         ));
   }
@@ -330,10 +325,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].isNotice").description("공지글?"),
                 fieldWithPath("list[].isSecret").description("비밀글?"),
                 fieldWithPath("list[].isTemp").description("임시저장?"),
-                fieldWithPath("list[].size").description("총 게시물 수"),
-                subsectionWithPath("list[].files").description(
-                        "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional().type(JsonFieldType.ARRAY)
+                fieldWithPath("list[].size").description("총 게시물 수")
             )
         ));
   }
@@ -700,6 +692,8 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("code").description("성공 : 0")
             )
         ));
+
+    Assertions.assertTrue(fileRepository.findById(generalImageFile.getId()).isEmpty());
   }
 
   @Test
@@ -794,10 +788,7 @@ public class PostingControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].isNotice").description("공지글?"),
                 fieldWithPath("list[].isSecret").description("비밀글?"),
                 fieldWithPath("list[].isTemp").description("임시저장?"),
-                fieldWithPath("list[].size").description("총 게시물 수"),
-                subsectionWithPath("list[].files").description(
-                        "첨부파일 정보 (.id, .fileName, .filePath, .fileSize, .uploadTime, .ipAddress)")
-                    .optional().type(JsonFieldType.ARRAY)
+                fieldWithPath("list[].size").description("총 게시물 수")
             )
         ));
   }


### PR DESCRIPTION
## 연관 issue
close: #250 , #252 

## 프론트 전달사항
1. 게시물 목록 형태의 Response에서 `files` 가 전달되지 않습니다. (null)
2. 게시물 수정시 추가할 파일만 `file` 파라미터로 주시고, 삭제할 파일은 `/v1/post/delete/{fileId}` API를 사용하시면 됩니다.