### PR TITLE
Feature/#266 member api 요청

### DIFF
--- a/src/docs/asciidoc/member_info.adoc
+++ b/src/docs/asciidoc/member_info.adoc
@@ -228,3 +228,27 @@ include::{snippets}/member-otherInfo-ById/response-body.adoc[]
 ==== Response Fields
 
 include::{snippets}/member-otherInfo-ById/response-fields.adoc[]
+
+== *다중 회원 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/member-multi/http-request.adoc[]
+
+==== Request Parameters
+
+include::{snippets}/member-multi/request-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member-multi/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/member-multi/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/member-multi/response-fields.adoc[]

--- a/src/main/java/keeper/project/homepage/entity/member/MemberEntity.java
+++ b/src/main/java/keeper/project/homepage/entity/member/MemberEntity.java
@@ -250,11 +250,11 @@ public class MemberEntity implements UserDetails, Serializable {
   public MultiMemberResponseDto toMultiMemberResponseDto() {
     return MultiMemberResponseDto.builder()
         .id(this.id)
-        .nickname(this.nickName)
+        .nickName(this.nickName)
         .thumbnailPath(this.getThumbnailPath())
         .generation(this.generation)
-        .memberJobs(this.getJobs())
-        .memberType(this.memberType.getName())
+        .jobs(this.getJobs())
+        .type(this.memberType.getName())
         .msg("Success")
         .build();
   }

--- a/src/main/java/keeper/project/homepage/entity/member/MemberEntity.java
+++ b/src/main/java/keeper/project/homepage/entity/member/MemberEntity.java
@@ -23,6 +23,7 @@ import javax.persistence.Transient;
 import keeper.project.homepage.entity.ThumbnailEntity;
 import keeper.project.homepage.entity.posting.PostingEntity;
 import keeper.project.homepage.entity.study.StudyHasMemberEntity;
+import keeper.project.homepage.user.dto.member.MultiMemberResponseDto;
 import keeper.project.homepage.util.EnvironmentProperty;
 import keeper.project.homepage.util.service.ThumbnailService.DefaultThumbnailInfo;
 import lombok.AllArgsConstructor;
@@ -244,5 +245,17 @@ public class MemberEntity implements UserDetails, Serializable {
     this.level = (this.level == null ? 0 : this.level);
     this.merit = (this.merit == null ? 0 : this.merit);
     this.demerit = (this.demerit == null ? 0 : this.demerit);
+  }
+
+  public MultiMemberResponseDto toMultiMemberResponseDto() {
+    return MultiMemberResponseDto.builder()
+        .id(this.id)
+        .nickname(this.nickName)
+        .thumbnailPath(this.getThumbnailPath())
+        .generation(this.generation)
+        .memberJobs(this.getJobs())
+        .memberType(this.memberType.getName())
+        .msg("Success")
+        .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/member/MemberController.java
@@ -9,6 +9,7 @@ import keeper.project.homepage.user.dto.member.MemberDto;
 import keeper.project.homepage.user.dto.member.MemberFollowDto;
 import keeper.project.homepage.common.dto.result.CommonResult;
 import keeper.project.homepage.common.dto.result.ListResult;
+import keeper.project.homepage.user.dto.member.MultiMemberResponseDto;
 import keeper.project.homepage.user.dto.member.OtherMemberInfoResult;
 import keeper.project.homepage.common.dto.result.SingleResult;
 import keeper.project.homepage.common.service.ResponseService;
@@ -62,6 +63,14 @@ public class MemberController {
   ) {
     return responseService.getSuccessSingleResult(
         memberService.getOtherMember(otherMemberId));
+  }
+
+  @Secured("ROLE_회원")
+  @GetMapping(value = "/multi")
+  public ListResult<MultiMemberResponseDto> getMultiMembers(
+      @RequestParam List<Long> ids
+  ) {
+    return responseService.getSuccessListResult(memberService.getMultiMembers(ids));
   }
 
   @GetMapping(value = "")

--- a/src/main/java/keeper/project/homepage/user/dto/member/MultiMemberResponseDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/MultiMemberResponseDto.java
@@ -1,0 +1,23 @@
+package keeper.project.homepage.user.dto.member;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MultiMemberResponseDto {
+
+  private Long id;
+  private String nickname;
+  private String thumbnailPath;
+  private Float generation;
+  private List<String> memberJobs;
+  private String memberType;
+  private String msg;
+
+}

--- a/src/main/java/keeper/project/homepage/user/dto/member/MultiMemberResponseDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/member/MultiMemberResponseDto.java
@@ -13,11 +13,11 @@ import lombok.NoArgsConstructor;
 public class MultiMemberResponseDto {
 
   private Long id;
-  private String nickname;
+  private String nickName;
   private String thumbnailPath;
   private Float generation;
-  private List<String> memberJobs;
-  private String memberType;
+  private List<String> jobs;
+  private String type;
   private String msg;
 
 }

--- a/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
+++ b/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import keeper.project.homepage.exception.member.CustomAccessVirtualMemberException;
+import keeper.project.homepage.user.dto.member.MultiMemberResponseDto;
 import keeper.project.homepage.user.dto.posting.PostingResponseDto;
 import keeper.project.homepage.user.dto.member.MemberFollowDto;
 import keeper.project.homepage.util.ImageCenterCrop;
@@ -91,7 +92,7 @@ public class MemberService {
   }
 
   private void checkVirtualMember(Long id) {
-    if(id.equals(VIRTUAL_MEMBER_ID)) {
+    if (id.equals(VIRTUAL_MEMBER_ID)) {
       throw new CustomAccessVirtualMemberException();
     }
   }
@@ -118,14 +119,39 @@ public class MemberService {
     List<MemberEntity> memberEntityList = memberRepository.findAll();
 
     for (MemberEntity memberEntity : memberEntityList) {
-      if(memberEntity.getMemberType() != null && memberEntity.getMemberType().getId() == 5) continue;
-      if(memberEntity.getId().equals(VIRTUAL_MEMBER_ID)) continue;
+      if (memberEntity.getMemberType() != null && memberEntity.getMemberType().getId() == 5) {
+        continue;
+      }
+      if (memberEntity.getId().equals(VIRTUAL_MEMBER_ID)) {
+        continue;
+      }
       OtherMemberInfoResult otherMemberInfoResult = new OtherMemberInfoResult(memberEntity);
       otherMemberInfoResult.setCheckFollow(isMyFollowee(memberEntity), isMyFollower(memberEntity));
       otherMemberInfoResultList.add(otherMemberInfoResult);
     }
 
     return otherMemberInfoResultList;
+  }
+
+  public List<MultiMemberResponseDto> getMultiMembers(List<Long> ids) {
+    List<MultiMemberResponseDto> multiMemberResponseDtos = new ArrayList<>();
+
+    for (Long id : ids) {
+      Optional<MemberEntity> member = memberRepository.findById(id);
+      if (member.isPresent()) {
+        if (member.get().getId().equals(VIRTUAL_MEMBER_ID)) {
+          multiMemberResponseDtos.add(
+              MultiMemberResponseDto.builder().msg("Fail: Access Virtual Member").build());
+        } else {
+          multiMemberResponseDtos.add(member.get().toMultiMemberResponseDto());
+        }
+      } else {
+        multiMemberResponseDtos.add(
+            MultiMemberResponseDto.builder().msg("Fail: Not Exist Member").build());
+      }
+    }
+
+    return multiMemberResponseDtos;
   }
 
   public void follow(Long myId, Long memberId) {

--- a/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
+++ b/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
@@ -141,13 +141,13 @@ public class MemberService {
       if (member.isPresent()) {
         if (member.get().getId().equals(VIRTUAL_MEMBER_ID)) {
           multiMemberResponseDtos.add(
-              MultiMemberResponseDto.builder().msg("Fail: Access Virtual Member").build());
+              MultiMemberResponseDto.builder().id(id).msg("Fail: Access Virtual Member").build());
         } else {
           multiMemberResponseDtos.add(member.get().toMultiMemberResponseDto());
         }
       } else {
         multiMemberResponseDtos.add(
-            MultiMemberResponseDto.builder().msg("Fail: Not Exist Member").build());
+            MultiMemberResponseDto.builder().id(id).msg("Fail: Not Exist Member").build());
       }
     }
 

--- a/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
@@ -186,4 +186,38 @@ public class MemberControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("list[].msg").description("멤버 조회 성공 여부 (실패 시 이유 반환)")
             )));
   }
+
+  @Test
+  @DisplayName("다중 회원 조회 - Virtual Member")
+  public void getMultiMembersWithVirtualMember() throws Exception {
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    String ids = "1";
+
+    params.add("ids", ids);
+    mockMvc.perform(get("/v1/members/multi")
+            .header("Authorization", userToken)
+            .params(params))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.list[0].id").value(1))
+        .andExpect(jsonPath("$.list[0].msg").value("Fail: Access Virtual Member"));
+  }
+
+  @Test
+  @DisplayName("다중 회원 조회 - 존재하지 않는 Member")
+  public void getMultiMembersWithNotExistMember() throws Exception {
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    String ids = "3";
+
+    params.add("ids", ids);
+    mockMvc.perform(get("/v1/members/multi")
+            .header("Authorization", userToken)
+            .params(params))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.list[0].id").value(3))
+        .andExpect(jsonPath("$.list[0].msg").value("Fail: Not Exist Member"));
+  }
 }

--- a/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
@@ -2,13 +2,18 @@ package keeper.project.homepage.user.controller.member;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import keeper.project.homepage.ApiControllerTestHelper;
 import keeper.project.homepage.entity.member.MemberEntity;
 import lombok.extern.log4j.Log4j2;
@@ -17,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 @Transactional
 @Log4j2
@@ -145,5 +152,38 @@ public class MemberControllerTest extends ApiControllerTestHelper {
         .andDo(print())
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.msg").value("보유한 권한으로 접근할수 없는 리소스 입니다"));
+  }
+
+  @Test
+  @DisplayName("다중 회원 조회 - 성공")
+  public void getMultiMembersSuccess() throws Exception {
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    String ids = userEntity.getId() + "," + adminEntity.getId() + "," + "1,3";
+
+    params.add("ids", ids);
+    mockMvc.perform(get("/v1/members/multi")
+            .header("Authorization", userToken)
+            .params(params))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andDo(document("member-multi",
+            requestParameters(
+                parameterWithName("ids").description("조회하고자 하는 멤버 ID 리스트 ex) /v1/members/multi?ids=1,2,3")
+            ),
+            responseFields(
+                fieldWithPath("success").description("성공: true +\n실패: false"),
+                fieldWithPath("code").description("성공 시 0을 반환"),
+                fieldWithPath("msg").description("성공: 성공하였습니다 +\n실패: 에러 메세지 반환"),
+                fieldWithPath("list[].id").description("멤버 ID").optional(),
+                fieldWithPath("list[].nickName").description("멤버 닉네임").optional(),
+                fieldWithPath("list[].thumbnailPath").description("회원의 썸네일 이미지 조회 api path")
+                    .optional(),
+                fieldWithPath("list[].generation").description("멤버 기수 (7월 이후는 N.5기)").optional(),
+                fieldWithPath("list[].jobs").description(
+                        "동아리 직책: null, ROLE_회장, ROLE_부회장, ROLE_대외부장, ROLE_학술부장, ROLE_전산관리자, ROLE_서기, ROLE_총무, ROLE_사서")
+                    .optional(),
+                fieldWithPath("list[].type").description("회원 상태: null, 비회원, 정회원, 휴면회원, 졸업회원, 탈퇴").optional(),
+                fieldWithPath("list[].msg").description("멤버 조회 성공 여부 (실패 시 이유 반환)")
+            )));
   }
 }

--- a/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
@@ -174,7 +174,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
                 fieldWithPath("success").description("성공: true +\n실패: false"),
                 fieldWithPath("code").description("성공 시 0을 반환"),
                 fieldWithPath("msg").description("성공: 성공하였습니다 +\n실패: 에러 메세지 반환"),
-                fieldWithPath("list[].id").description("멤버 ID").optional(),
+                fieldWithPath("list[].id").description("멤버 ID"),
                 fieldWithPath("list[].nickName").description("멤버 닉네임").optional(),
                 fieldWithPath("list[].thumbnailPath").description("회원의 썸네일 이미지 조회 api path")
                     .optional(),

--- a/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
+++ b/src/test/java/keeper/project/homepage/user/controller/member/MemberControllerTest.java
@@ -208,7 +208,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
   @DisplayName("다중 회원 조회 - 존재하지 않는 Member")
   public void getMultiMembersWithNotExistMember() throws Exception {
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-    String ids = "3";
+    String ids = "-999";
 
     params.add("ids", ids);
     mockMvc.perform(get("/v1/members/multi")
@@ -217,7 +217,7 @@ public class MemberControllerTest extends ApiControllerTestHelper {
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.list[0].id").value(3))
+        .andExpect(jsonPath("$.list[0].id").value(-999))
         .andExpect(jsonPath("$.list[0].msg").value("Fail: Not Exist Member"));
   }
 }


### PR DESCRIPTION
## 연관 issue
close: #266

## 프론트 전달사항
- /v1/members/multi?ids=1,2,3 같이 멤버 리스트 ID를 콤마로 구분하여 파라미터로 전송합니다.
- 멤버 ID가 정상적으로 존재하는 경우 해당 멤버에 알맞은 데이터가 전달됩니다.
- 멤버 ID 리스트 중 멤버 ID가 존재하지 않거나 가상의 멤버에 접근하는 경우 API 요구사항에 따라 API 요청 실패 처리가 되는 것이 아닌 실패 데이터가 추가되고 다른 정상적인 멤버 데이터는 성공적으로 전달됩니다.
- 멤버 ID의 조회 실패에 대한 실패 데이터는 멤버 ID와 실패한 이유를 전송하게 되고 나머지 데이터는 null로 전송됩니다.