### PR TITLE
Feature/게시판 파일 삭제 로직 수정

### DIFF
--- a/src/docs/asciidoc/posting.adoc
+++ b/src/docs/asciidoc/posting.adoc
@@ -271,6 +271,27 @@ include::{snippets}/post-file-delete/http-response.adoc[]
 
 include::{snippets}/post-file-delete/response-body.adoc[]
 
+== 게시글 첨부파일 여러개 삭제
+
+=== 요청
+
+==== Request
+
+include::{snippets}/post-delete-files/request-body.adoc[]
+
+==== Request Parameters
+
+include::{snippets}/post-delete-files/request-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/post-delete-files/http-response.adoc[]
+
+==== Response Body
+
+include::{snippets}/post-delete-files/response-body.adoc[]
 
 == 게시글 삭제
 

--- a/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
@@ -198,9 +198,15 @@ public class PostingController {
   }
 
   @GetMapping(value = "/delete/{fileId}")
-  public CommonResult deleteFile(@PathVariable("fileId") Long fileId){
+  public CommonResult deleteFile(@PathVariable("fileId") Long fileId) {
     fileService.deleteFileById(fileId);
 
+    return responseService.getSuccessResult();
+  }
+
+  @DeleteMapping(value = "/files")
+  public CommonResult deleteFiles(@RequestParam(value = "fileIdList") List<Long> fileIdList) {
+    fileService.deleteFilesByIdList(fileIdList);
     return responseService.getSuccessResult();
   }
 

--- a/src/main/java/keeper/project/homepage/util/service/FileService.java
+++ b/src/main/java/keeper/project/homepage/util/service/FileService.java
@@ -147,6 +147,12 @@ public class FileService {
     deleteFileEntityById(deleteId);
   }
 
+  public void deleteFilesByIdList(List<Long> deleteIdList) {
+    for (Long deleteId : deleteIdList) {
+      deleteFileById(deleteId);
+    }
+  }
+
   // TODO : thumbnail delete와 합치기
   public void deleteOriginalThumbnail(ThumbnailEntity deleteThumbnail) {
     // 기본 썸네일이면 삭제 X

--- a/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
+++ b/src/test/java/keeper/project/homepage/controller/posting/PostingControllerTest.java
@@ -703,6 +703,37 @@ public class PostingControllerTest extends ApiControllerTestHelper {
   }
 
   @Test
+  @DisplayName("파일 ID 리스트를 받아 파일들 삭제")
+  public void deleteFiles() throws Exception {
+    FileEntity generalImageFile2 = generateFileEntity();
+    FileEntity generalImageFile3 = generateFileEntity();
+    String params = generalImageFile.getId().toString() + "," +
+        generalImageFile2.getId().toString() + "," +
+        generalImageFile3.getId().toString();
+
+    ResultActions result = mockMvc.perform(
+        RestDocumentationRequestBuilders.delete("/v1/post/files")
+            .param("fileIdList", params)
+            .header("Authorization", userToken));
+    result.andExpect(MockMvcResultMatchers.status().isOk())
+        .andDo(print())
+        .andDo(document("post-delete-files",
+            requestParameters(
+                parameterWithName("fileIdList").description("삭제할 파일 ID 리스트")
+            ), responseFields(
+                fieldWithPath("success").description("성공: true +\n실패: false"),
+                fieldWithPath("msg").description(""),
+                fieldWithPath("code").description("성공 : 0")
+            )
+        ));
+
+    Assertions.assertTrue(fileRepository.findById(generalImageFile.getId()).isEmpty());
+    Assertions.assertTrue(fileRepository.findById(generalImageFile2.getId()).isEmpty());
+    Assertions.assertTrue(fileRepository.findById(generalImageFile3.getId()).isEmpty());
+
+  }
+
+  @Test
   @DisplayName("게시글 삭제")
   public void deletePosting() throws Exception {
     ResultActions result = mockMvc.perform(


### PR DESCRIPTION
## 연관 issue
close: #268 

## 참고 사항
혹시 몰라서 기존 파일 삭제 관련 코드는 그대로 두었습니다. 문제가 없다면 추후 삭제하도록 하겠습니다.

## 프론트 전달사항
기존 GET v1/post/delete/{fileId} 에서 파라미터로 file ID 리스트를 받아 삭제할 수 있도록 변경하였고,
REST API 규칙을 적용해 DELETE v1/post/files?fileIdList=0000,1111,2222 와 같은 형식으로 URI를 변경하였습니다.

