### PR TITLE
Feature/#271 이미지 로딩 개선

### DIFF
--- a/src/main/java/keeper/project/homepage/admin/controller/library/BookManageController.java
+++ b/src/main/java/keeper/project/homepage/admin/controller/library/BookManageController.java
@@ -2,7 +2,7 @@ package keeper.project.homepage.admin.controller.library;
 
 import javax.servlet.http.HttpServletRequest;
 import keeper.project.homepage.admin.service.library.BookManageService;
-import keeper.project.homepage.util.ImageCenterCrop;
+import keeper.project.homepage.util.ImageCenterCropping;
 import keeper.project.homepage.admin.dto.library.BookDto;
 import keeper.project.homepage.common.dto.result.CommonResult;
 import keeper.project.homepage.entity.ThumbnailEntity;
@@ -64,7 +64,7 @@ public class BookManageController {
       ip = httpServletRequest.getRemoteAddr();
     }
 
-    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(),
+    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(),
         thumbnail, ThumbnailSize.LARGE, ip);
 
     if (thumbnailEntity == null) {

--- a/src/main/java/keeper/project/homepage/admin/service/about/AdminAboutSubtitleService.java
+++ b/src/main/java/keeper/project/homepage/admin/service/about/AdminAboutSubtitleService.java
@@ -9,7 +9,7 @@ import keeper.project.homepage.exception.CustomAboutFailedException;
 import keeper.project.homepage.exception.file.CustomThumbnailEntityNotFoundException;
 import keeper.project.homepage.repository.etc.StaticWriteSubtitleImageRepository;
 import keeper.project.homepage.repository.etc.StaticWriteTitleRepository;
-import keeper.project.homepage.util.ImageCenterCrop;
+import keeper.project.homepage.util.ImageCenterCropping;
 import keeper.project.homepage.util.service.FileService;
 import keeper.project.homepage.util.service.ThumbnailService;
 import keeper.project.homepage.util.service.ThumbnailService.ThumbnailSize;
@@ -58,7 +58,7 @@ public class AdminAboutSubtitleService {
       thumbnailEntity = thumbnailService.findById(9L);
       System.out.println("디폴트 이미지로 설정되었습니다.");
     } else {
-      thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(), thumbnail,
+      thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(), thumbnail,
           ThumbnailSize.LARGE, ipAddress);
       System.out.println("새로운 이미지가 생성되었습니다.");
     }
@@ -96,7 +96,7 @@ public class AdminAboutSubtitleService {
       newThumbnail = thumbnailService.findById(9L);
       System.out.println("디폴트 이미지로 설정되었습니다.");
     } else {
-      newThumbnail = thumbnailService.saveThumbnail(new ImageCenterCrop(), thumbnail,
+      newThumbnail = thumbnailService.saveThumbnail(new ImageCenterCropping(), thumbnail,
           ThumbnailSize.LARGE, ipAddress);
       System.out.println("새로운 이미지가 생성되었습니다.");
     }

--- a/src/main/java/keeper/project/homepage/common/controller/util/ImageController.java
+++ b/src/main/java/keeper/project/homepage/common/controller/util/ImageController.java
@@ -2,6 +2,8 @@ package keeper.project.homepage.common.controller.util;
 
 
 import java.io.IOException;
+import keeper.project.homepage.util.ImageResizing;
+import keeper.project.homepage.util.ImageResizing.RESIZE_OPTION;
 import keeper.project.homepage.util.service.FileService;
 import keeper.project.homepage.util.service.ThumbnailService;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,8 @@ public class ImageController {
   public @ResponseBody
   byte[] getImage(@PathVariable("fileId") Long fileId) throws IOException {
 
-    return fileService.getImage(fileId);
+    return fileService.getByteArrayForImage(fileId,
+        new ImageResizing(RESIZE_OPTION.KEEP_RATIO_IN_OUTER_BOUNDARY), 800, 800);
   }
 
   @GetMapping(
@@ -37,6 +40,7 @@ public class ImageController {
   public @ResponseBody
   byte[] getThumbnail(@PathVariable("thumbnailId") Long thumbnailId) throws IOException {
 
-    return thumbnailService.getThumbnail(thumbnailId);
+    return thumbnailService.getByteArrayForThumbnailImage(thumbnailId,
+        new ImageResizing(RESIZE_OPTION.KEEP_RATIO_IN_OUTER_BOUNDARY), 800, 800);
   }
 }

--- a/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
+++ b/src/main/java/keeper/project/homepage/user/controller/posting/PostingController.java
@@ -21,7 +21,7 @@ import keeper.project.homepage.user.dto.posting.PostingResponseDto;
 import keeper.project.homepage.util.service.FileService;
 import keeper.project.homepage.common.service.ResponseService;
 import keeper.project.homepage.util.service.ThumbnailService;
-import keeper.project.homepage.util.ImageCenterCrop;
+import keeper.project.homepage.util.ImageCenterCropping;
 import keeper.project.homepage.util.service.ThumbnailService.ThumbnailSize;
 import keeper.project.homepage.user.service.posting.CommentService;
 import keeper.project.homepage.user.service.posting.PostingService;
@@ -108,7 +108,7 @@ public class PostingController {
       @RequestParam(value = "thumbnail", required = false) MultipartFile thumbnail,
       PostingDto dto) {
 
-    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(),
+    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(),
         thumbnail, ThumbnailSize.LARGE, dto.getIpAddress());
     dto.setThumbnailId(thumbnailEntity.getId());
     PostingEntity postingEntity = postingService.save(dto);
@@ -181,7 +181,7 @@ public class PostingController {
   }
 
   private ThumbnailEntity saveThumbnail(MultipartFile thumbnail, PostingDto dto) {
-    ThumbnailEntity newThumbnail = thumbnailService.saveThumbnail(new ImageCenterCrop(), thumbnail,
+    ThumbnailEntity newThumbnail = thumbnailService.saveThumbnail(new ImageCenterCropping(), thumbnail,
         ThumbnailSize.LARGE, dto.getIpAddress());
     if (newThumbnail == null) {
       throw new CustomThumbnailEntityNotFoundException("썸네일 저장 중에 에러가 발생했습니다.");

--- a/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
+++ b/src/main/java/keeper/project/homepage/user/service/member/MemberService.java
@@ -9,7 +9,7 @@ import keeper.project.homepage.exception.member.CustomAccessVirtualMemberExcepti
 import keeper.project.homepage.user.dto.member.MultiMemberResponseDto;
 import keeper.project.homepage.user.dto.posting.PostingResponseDto;
 import keeper.project.homepage.user.dto.member.MemberFollowDto;
-import keeper.project.homepage.util.ImageCenterCrop;
+import keeper.project.homepage.util.ImageCenterCropping;
 import keeper.project.homepage.common.dto.sign.EmailAuthDto;
 import keeper.project.homepage.user.dto.member.MemberDto;
 import keeper.project.homepage.user.dto.member.OtherMemberInfoResult;
@@ -276,7 +276,7 @@ public class MemberService {
 
     ThumbnailEntity prevThumbnail = memberEntity.getThumbnail();
 
-    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(), image,
+    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(), image,
         ThumbnailSize.LARGE, ipAddress);
 
     memberEntity.changeThumbnail(thumbnailEntity);

--- a/src/main/java/keeper/project/homepage/user/service/study/StudyService.java
+++ b/src/main/java/keeper/project/homepage/user/service/study/StudyService.java
@@ -22,7 +22,7 @@ import keeper.project.homepage.user.dto.member.MemberDto;
 import keeper.project.homepage.user.dto.study.StudyDto;
 import keeper.project.homepage.user.dto.study.StudyYearSeasonDto;
 import keeper.project.homepage.user.mapper.StudyMapper;
-import keeper.project.homepage.util.ImageCenterCrop;
+import keeper.project.homepage.util.ImageCenterCropping;
 import keeper.project.homepage.util.service.FileService;
 import keeper.project.homepage.util.service.ThumbnailService;
 import keeper.project.homepage.util.service.ThumbnailService.ThumbnailSize;
@@ -129,7 +129,7 @@ public class StudyService {
   }
 
   private ThumbnailEntity saveThumbnail(String ipAddress, MultipartFile thumbnail) {
-    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(),
+    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(),
         thumbnail, ThumbnailSize.STUDY, ipAddress);
 
     if (thumbnailEntity == null) {

--- a/src/main/java/keeper/project/homepage/util/ImageCenterCropping.java
+++ b/src/main/java/keeper/project/homepage/util/ImageCenterCropping.java
@@ -6,7 +6,7 @@ import java.io.File;
 import javax.imageio.ImageIO;
 import keeper.project.homepage.exception.file.CustomImageIOException;
 
-public class ImageCenterCrop implements ImageProcessing {
+public class ImageCenterCropping implements ImageProcessing {
 
   public void imageProcessing(File imageFile, int width, int height, String fileFormat) {
     BufferedImage bo_image;

--- a/src/main/java/keeper/project/homepage/util/ImageResizing.java
+++ b/src/main/java/keeper/project/homepage/util/ImageResizing.java
@@ -10,7 +10,55 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class ImageResizing implements ImageProcessing {
 
-  public void imageProcessing(File image, int width, int height, String fileFormat) {
+  public enum RESIZE_OPTION {
+    DEFAULT,
+    KEEP_RATIO,
+    KEEP_RATIO_IN_OUTER_BOUNDARY;
+  }
+
+  private RESIZE_OPTION resize_option;
+
+  public ImageResizing(RESIZE_OPTION resize_option) {
+    /**
+     * @param resize_option imageProcessing(.., dest_width, dest_height, ..)의 resize option
+     *                      DEFAULT : dest_width X dest_height 로 크기 변경
+     *                      KEEP_RATIO : 원본 이미지의 크기 비율을 유지, dest_width와 dest_height 중 크기 변화가 작은 길이에 맞추어 변경
+     *                      KEEP_RATIO_IN_OUTER_BOUNDARY : KEEP_RATIO 에서 원본 이미지의 너비와 높이가 dest_width, dest_height 보다 작다면 이미지 처리하지 않음
+     */
+    this.resize_option = resize_option;
+  }
+
+  private class Size {
+
+    private Integer width;
+    private Integer height;
+
+    Size(Integer width, Integer height) {
+      this.width = width;
+      this.height = height;
+    }
+
+    Integer getWidth() {
+      return this.width;
+    }
+
+    Integer getHeight() {
+      return this.height;
+    }
+  }
+
+  private Size getScaledSize(
+      Size image_size,
+      Size boundary_size) {
+    double widthRatio = boundary_size.getWidth() / (double) image_size.getWidth();
+    double heightRatio = boundary_size.getHeight() / (double) image_size.getHeight();
+    double ratio = Math.min(widthRatio, heightRatio);
+
+    return new Size((int) (image_size.getWidth() * ratio),
+        (int) (image_size.getHeight() * ratio));
+  }
+
+  public void imageProcessing(File image, int dest_width, int dest_height, String fileFormat) {
     BufferedImage bo_image;
     try {
       bo_image = ImageIO.read(image);
@@ -18,15 +66,36 @@ public class ImageResizing implements ImageProcessing {
       e.printStackTrace();
       throw new CustomImageIOException();
     }
-    BufferedImage bt_image = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
+    Size destSize;
+    switch (resize_option) {
+      case KEEP_RATIO_IN_OUTER_BOUNDARY:
+        if (bo_image.getWidth() <= dest_width && bo_image.getHeight() <= dest_height) {
+          return;
+        }
+        destSize = getScaledSize(
+            new Size(bo_image.getWidth(), bo_image.getHeight()),
+            new Size(dest_width, dest_height));
+        break;
+      case KEEP_RATIO:
+        destSize = getScaledSize(
+            new Size(bo_image.getWidth(), bo_image.getHeight()),
+            new Size(dest_width, dest_height));
+        break;
+      default:
+        destSize = new Size(dest_width, dest_height);
+        break;
+    }
+    BufferedImage bt_image = new BufferedImage(destSize.getWidth(), destSize.getHeight(),
+        BufferedImage.TYPE_3BYTE_BGR);
 
     Graphics2D graphic = bt_image.createGraphics();
-    graphic.drawImage(bo_image, 0, 0, width, height, null);
+    graphic.drawImage(bo_image, 0, 0, destSize.getWidth(), destSize.getHeight(), null);
     try {
       ImageIO.write(bt_image, fileFormat, image);
     } catch (Exception e) {
       e.printStackTrace();
       throw new CustomImageIOException();
     }
+
   }
 }

--- a/src/main/java/keeper/project/homepage/util/ImageResizing.java
+++ b/src/main/java/keeper/project/homepage/util/ImageResizing.java
@@ -8,7 +8,7 @@ import keeper.project.homepage.exception.file.CustomImageIOException;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-public class ImageResize implements ImageProcessing {
+public class ImageResizing implements ImageProcessing {
 
   public void imageProcessing(File image, int width, int height, String fileFormat) {
     BufferedImage bo_image;

--- a/src/main/java/keeper/project/homepage/util/service/ThumbnailService.java
+++ b/src/main/java/keeper/project/homepage/util/service/ThumbnailService.java
@@ -82,12 +82,34 @@ public class ThumbnailService {
     }
   }
 
-  public byte[] getThumbnail(Long thumbnailId) throws IOException {
-    ThumbnailEntity thumbnail = findById(thumbnailId);
-    String thumbnailPath = System.getProperty("user.dir") + File.separator + thumbnail.getPath();
-    File file = new File(thumbnailPath);
+  public byte[] getByteArrayForThumbnailImage(Long thumbnailId, ImageProcessing imageProcessing,
+      Integer width, Integer height) throws IOException {
+    /**
+     * @return byte array for preprocessed thumbnail image
+     */
+    File file = getThumbnailFile(thumbnailId);
+    imageProcessing.imageProcessing(file, width, height, "jpg");
     InputStream in = new FileInputStream(file);
     return IOUtils.toByteArray(in);
+  }
+
+  public byte[] getByteArrayForThumbnailImage(Long thumbnailId) throws IOException {
+    /**
+     * @return byte array for original thumbnail image
+     */
+    File file = getThumbnailFile(thumbnailId);
+    InputStream in = new FileInputStream(file);
+    return IOUtils.toByteArray(in);
+  }
+
+  private File getThumbnailFile(Long thumbnailId) {
+    ThumbnailEntity thumbnail = findById(thumbnailId);
+    String thumbnailPath = System.getProperty("user.dir") + File.separator + thumbnail.getPath();
+    File imageFile = new File(thumbnailPath);
+    if (imageFile.exists() == false) {
+      throw new CustomFileNotFoundException();
+    }
+    return imageFile;
   }
 
   public ThumbnailEntity saveThumbnail(ImageProcessing imageProcessing, MultipartFile multipartFile,

--- a/src/test/java/keeper/project/homepage/service/ThumbnailServiceTest.java
+++ b/src/test/java/keeper/project/homepage/service/ThumbnailServiceTest.java
@@ -3,31 +3,18 @@ package keeper.project.homepage.service;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import keeper.project.homepage.ApiControllerTestHelper;
 import keeper.project.homepage.entity.FileEntity;
 import keeper.project.homepage.entity.ThumbnailEntity;
-import keeper.project.homepage.entity.member.MemberEntity;
-import keeper.project.homepage.entity.posting.CategoryEntity;
-import keeper.project.homepage.entity.posting.PostingEntity;
-import keeper.project.homepage.util.FileConversion;
-import keeper.project.homepage.util.ImageCenterCrop;
-import keeper.project.homepage.util.service.FileService;
-import keeper.project.homepage.util.service.ThumbnailService;
+import keeper.project.homepage.util.ImageCenterCropping;
 import keeper.project.homepage.util.service.ThumbnailService.DefaultThumbnailInfo;
 import keeper.project.homepage.util.service.ThumbnailService.ThumbnailSize;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -56,7 +43,7 @@ public class ThumbnailServiceTest extends ApiControllerTestHelper {
 
     //test
     Assertions.assertTrue(new File(imageFilePath).exists(), "test할 이미지 파일이 없습니다.");
-    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(),
+    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(),
         originalImage, ThumbnailSize.LARGE, ipAddress);
     Assertions.assertTrue(
         new File(
@@ -84,7 +71,7 @@ public class ThumbnailServiceTest extends ApiControllerTestHelper {
 
     //test
     Assertions.assertTrue(new File(defaultFilePath).exists(), "test할 이미지 파일이 없습니다.");
-    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCrop(),
+    ThumbnailEntity thumbnailEntity = thumbnailService.saveThumbnail(new ImageCenterCropping(),
         null, ThumbnailSize.LARGE, ipAddress);
 
     log.info(System.getProperty("user.dir") + File.separator + thumbnailEntity.getPath());


### PR DESCRIPTION
## 연관 issue
close : #271 

## 프론트 전달사항
`null`

## 변경사항
- `[get] /v1/image/{fileId}` 와 `[get] /v1/thumbnail/{thumbnailId}` 의 내부 로직 변경사항입니다.
- 이미지 로딩 속도 개선을 위해 로딩할 때 800x800 pixel 내로 크기를 줄여서 전달합니다.