### PR TITLE
fix: 팀 정보 수정 시 본인이 생성한 팀이 아니면 수정 불가능하게 변경

### DIFF
--- a/src/main/java/keeper/project/homepage/user/service/ctf/CtfTeamService.java
+++ b/src/main/java/keeper/project/homepage/user/service/ctf/CtfTeamService.java
@@ -95,6 +95,11 @@ public class CtfTeamService {
 
     ctfUtilService.checkJoinable(teamEntity.getCtfContestEntity().getId());
 
+    Long modifyMemberId = authService.getMemberIdByJWT();
+    if (modifyMemberId.equals(teamEntity.getCreator().getId())) {
+      throw new RuntimeException("본인이 생성한 팀이 아니면 수정할 수 없습니다.");
+    }
+
     teamEntity.setName(ctfTeamDto.getName());
     teamEntity.setDescription(ctfTeamDto.getDescription());
 


### PR DESCRIPTION
## 연관 issue

## 프론트 전달사항