### PR TITLE
fix: 활동조사 추가 수정사항

### DIFF
--- a/src/main/java/keeper/project/homepage/user/dto/clerk/response/ClosedSurveyInformationResponseDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/clerk/response/ClosedSurveyInformationResponseDto.java
@@ -25,19 +25,12 @@ public class ClosedSurveyInformationResponseDto {
   private Long replyId;
 
   public static ClosedSurveyInformationResponseDto of(SurveyEntity survey,
-      SurveyMemberReplyEntity surveyMemberReply) {
+      Long replyId) {
     return ClosedSurveyInformationResponseDto.builder()
         .surveyId(survey.getId())
         .surveyName(survey.getName())
-        .replyId(surveyMemberReply.getReply().getId())
+        .replyId(replyId)
         .build();
   }
 
-  public static ClosedSurveyInformationResponseDto noResponse(SurveyEntity survey) {
-    return ClosedSurveyInformationResponseDto.builder()
-        .surveyId(survey.getId())
-        .surveyName(survey.getName())
-        .replyId(null)
-        .build();
-  }
 }

--- a/src/main/java/keeper/project/homepage/user/dto/clerk/response/ClosedSurveyInformationResponseDto.java
+++ b/src/main/java/keeper/project/homepage/user/dto/clerk/response/ClosedSurveyInformationResponseDto.java
@@ -33,10 +33,10 @@ public class ClosedSurveyInformationResponseDto {
         .build();
   }
 
-  public static ClosedSurveyInformationResponseDto notFound() {
+  public static ClosedSurveyInformationResponseDto noResponse(SurveyEntity survey) {
     return ClosedSurveyInformationResponseDto.builder()
-        .surveyId(-1L)
-        .surveyName(null)
+        .surveyId(survey.getId())
+        .surveyName(survey.getName())
         .replyId(null)
         .build();
   }

--- a/src/main/java/keeper/project/homepage/user/service/clerk/SurveyService.java
+++ b/src/main/java/keeper/project/homepage/user/service/clerk/SurveyService.java
@@ -167,9 +167,9 @@ public class SurveyService {
     Optional<SurveyMemberReplyEntity> surveyMemberReply = surveyMemberReplyRepository
         .findBySurveyIdAndMemberId(latestClosedSurvey.getId(), reqMemberId);
     if (surveyMemberReply.isEmpty()) {
-      return ClosedSurveyInformationResponseDto.noResponse(latestClosedSurvey);
+      return ClosedSurveyInformationResponseDto.of(latestClosedSurvey,null);
     }
-    return ClosedSurveyInformationResponseDto.of(latestClosedSurvey, surveyMemberReply.get());
+    return ClosedSurveyInformationResponseDto.of(latestClosedSurvey, surveyMemberReply.get().getReply().getId());
   }
 
 }

--- a/src/main/java/keeper/project/homepage/user/service/clerk/SurveyService.java
+++ b/src/main/java/keeper/project/homepage/user/service/clerk/SurveyService.java
@@ -167,7 +167,7 @@ public class SurveyService {
     Optional<SurveyMemberReplyEntity> surveyMemberReply = surveyMemberReplyRepository
         .findBySurveyIdAndMemberId(latestClosedSurvey.getId(), reqMemberId);
     if (surveyMemberReply.isEmpty()) {
-      return ClosedSurveyInformationResponseDto.notFound();
+      return ClosedSurveyInformationResponseDto.noResponse(latestClosedSurvey);
     }
     return ClosedSurveyInformationResponseDto.of(latestClosedSurvey, surveyMemberReply.get());
   }

--- a/src/test/java/keeper/project/homepage/controller/clerk/SurveySpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/controller/clerk/SurveySpringTestHelper.java
@@ -33,6 +33,8 @@ public class SurveySpringTestHelper extends ApiControllerTestHelper {
 
   protected static final SurveyEntity NO_SURVEY = SurveyEntity.builder().id(-1L).build();
 
+  protected static final Long NO_SURVEY_REPLY = null;
+
   @Autowired
   protected SurveyReplyExcuseRepository surveyReplyExcuseRepository;
 

--- a/src/test/java/keeper/project/homepage/controller/clerk/SurveySpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/controller/clerk/SurveySpringTestHelper.java
@@ -33,8 +33,6 @@ public class SurveySpringTestHelper extends ApiControllerTestHelper {
 
   protected static final SurveyEntity NO_SURVEY = SurveyEntity.builder().id(-1L).build();
 
-  protected static final Long NO_SURVEY_REPLY = null;
-
   @Autowired
   protected SurveyReplyExcuseRepository surveyReplyExcuseRepository;
 

--- a/src/test/java/keeper/project/homepage/user/service/clerk/SurveyServiceTest.java
+++ b/src/test/java/keeper/project/homepage/user/service/clerk/SurveyServiceTest.java
@@ -342,11 +342,11 @@ public class SurveyServiceTest extends SurveySpringTestHelper {
     ClosedSurveyInformationResponseDto result = surveyService.getLatestClosedSurveyInformation();
 
     //then
-    assertThat(ClosedSurveyInformationResponseDto.noResponse(survey).getSurveyId())
+    assertThat(ClosedSurveyInformationResponseDto.of(survey,null).getSurveyId())
         .isEqualTo(result.getSurveyId());
-    assertThat(ClosedSurveyInformationResponseDto.noResponse(survey).getSurveyName())
+    assertThat(ClosedSurveyInformationResponseDto.of(survey,null).getSurveyName())
         .isEqualTo(result.getSurveyName());
-    assertThat(ClosedSurveyInformationResponseDto.noResponse(survey).getReplyId())
+    assertThat(ClosedSurveyInformationResponseDto.of(survey,null).getReplyId())
         .isEqualTo(result.getReplyId());
   }
 
@@ -378,8 +378,7 @@ public class SurveyServiceTest extends SurveySpringTestHelper {
         .isEqualTo(result.getSurveyId());
     assertThat(NO_SURVEY.getName())
         .isEqualTo(result.getSurveyName());
-    assertThat(NO_SURVEY_REPLY)
-        .isEqualTo(result.getReplyId());
+    assertThat(result.getReplyId()).isNull();
   }
 
 

--- a/src/test/java/keeper/project/homepage/user/service/clerk/SurveyServiceTest.java
+++ b/src/test/java/keeper/project/homepage/user/service/clerk/SurveyServiceTest.java
@@ -335,18 +335,18 @@ public class SurveyServiceTest extends SurveySpringTestHelper {
     //given
     setAuthentication(user);
 
-    generateSurvey(LocalDateTime.now().minusDays(4),
+    SurveyEntity survey = generateSurvey(LocalDateTime.now().minusDays(4),
         LocalDateTime.now().minusDays(2), true);
 
     //when
     ClosedSurveyInformationResponseDto result = surveyService.getLatestClosedSurveyInformation();
 
     //then
-    assertThat(ClosedSurveyInformationResponseDto.notFound().getSurveyId())
+    assertThat(ClosedSurveyInformationResponseDto.noResponse(survey).getSurveyId())
         .isEqualTo(result.getSurveyId());
-    assertThat(ClosedSurveyInformationResponseDto.notFound().getSurveyName())
+    assertThat(ClosedSurveyInformationResponseDto.noResponse(survey).getSurveyName())
         .isEqualTo(result.getSurveyName());
-    assertThat(ClosedSurveyInformationResponseDto.notFound().getReplyId())
+    assertThat(ClosedSurveyInformationResponseDto.noResponse(survey).getReplyId())
         .isEqualTo(result.getReplyId());
   }
 
@@ -374,11 +374,11 @@ public class SurveyServiceTest extends SurveySpringTestHelper {
     ClosedSurveyInformationResponseDto result = surveyService.getLatestClosedSurveyInformation();
 
     //then
-    assertThat(ClosedSurveyInformationResponseDto.notFound().getSurveyId())
+    assertThat(NO_SURVEY.getId())
         .isEqualTo(result.getSurveyId());
-    assertThat(ClosedSurveyInformationResponseDto.notFound().getSurveyName())
+    assertThat(NO_SURVEY.getName())
         .isEqualTo(result.getSurveyName());
-    assertThat(ClosedSurveyInformationResponseDto.notFound().getReplyId())
+    assertThat(NO_SURVEY_REPLY)
         .isEqualTo(result.getReplyId());
   }
 


### PR DESCRIPTION
close #392

### 프론트 전달 사항
가장 최근에 종료된 설문 불러올 때,
무응답 했을 경우에 replyId 만 null 처리하고 surveyId, surveyName은 그대로 반환되도록 수정