### PR TITLE
Feature/#443 테스트 할 때 embedded redis를 사용하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ dependencies {
     // Crawler
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'org.seleniumhq.selenium:selenium-java:4.1.4'
-    
+    implementation('it.ozimov:embedded-redis:0.7.3') { exclude group: "org.slf4j", module: "slf4j-simple" }
+
 
     compileOnly 'org.projectlombok:lombok'
 
@@ -65,7 +66,6 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
-
 }
 
 /******* Start Spring Rest Docs *******/

--- a/src/main/java/keeper/project/homepage/config/redis/RedisConfig.java
+++ b/src/main/java/keeper/project/homepage/config/redis/RedisConfig.java
@@ -1,8 +1,11 @@
 package keeper.project.homepage.config.redis;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -16,9 +19,16 @@ public class RedisConfig {
   @Value("${spring.redis.port}")
   private int port;
 
+  public int getPort() {
+    if (port == -1) {
+      return port = findAvailablePort();
+    }
+    return port;
+  }
+
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory(host, port);
+    return new LettuceConnectionFactory(host, getPort());
   }
 
   @Bean
@@ -26,5 +36,13 @@ public class RedisConfig {
     RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     return redisTemplate;
+  }
+
+  public int findAvailablePort() {
+    try (ServerSocket serverSocket = new ServerSocket(0)) {
+      return serverSocket.getLocalPort();
+    } catch (IOException e) {
+      throw new IllegalStateException("Port is not available");
+    }
   }
 }

--- a/src/main/java/keeper/project/homepage/config/redis/TestRedisConfiguration.java
+++ b/src/main/java/keeper/project/homepage/config/redis/TestRedisConfiguration.java
@@ -1,0 +1,43 @@
+package keeper.project.homepage.config.redis;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import redis.embedded.RedisServer;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+@Profile("test")
+public class TestRedisConfiguration {
+
+  private final RedisConfig redisConfig;
+
+  private RedisServer redisServer;
+
+  @PostConstruct
+  public void postConstruct() {
+    this.redisServer = RedisServer.builder()
+        .port(redisConfig.getPort())
+        .setting("maxmemory 128M")
+        .build();
+    redisServer.start();
+  }
+
+  @PreDestroy
+  public void preDestroy() {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+}

--- a/src/test/resources/config/application.properties
+++ b/src/test/resources/config/application.properties
@@ -1,0 +1,3 @@
+spring.profiles.active=test
+# \uD14C\uC2A4\uD2B8\uC6A9 Embedded Redis \uC124\uC815
+spring.redis.port=-1


### PR DESCRIPTION
## 연관 issue

close : #443

- #443

개발 하면서 겪은 시행착오 포스팅도 함께 올리겠습니다!
- [키퍼 홈페이지 리뉴얼 - Embedded Redis 적용](https://gusah009.github.io/keeper-homepage/2022-10-12-%ED%82%A4%ED%8D%BC%20%ED%99%88%ED%8E%98%EC%9D%B4%EC%A7%80%20%EB%A6%AC%EB%89%B4%EC%96%BC%20-%20Embedded%20Redis%20%EC%A0%81%EC%9A%A9/)

예상과 달리 **기존 외부 Redis**를 사용할 때 보다 **Embedded Redis를** 사용할 때가 더 빨랐습니다..!

### 외부 Redis로 테스트
<img width="298" alt="image" src="https://user-images.githubusercontent.com/26597702/195225881-d3981e19-9a00-4aca-bd67-2006987918cc.png">

### Embedded Redis로 테스트
<img width="304" alt="image" src="https://user-images.githubusercontent.com/26597702/195222685-84201483-069f-4b3f-a2ba-4f741dbcee4b.png">

## 프론트 전달사항
