### PR TITLE
Feature/#462 ctf 브루트포싱 방지 기능 제작

### DIFF
--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -82,6 +82,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .file(file)
         .dynamicInfo(dynamicInfo)
         .remainedSubmitCount(getVirtualTeamFlag(challenge).getRemainedSubmitCount())
+        .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime())
         .build();
   }
 

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -54,6 +54,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .score(score)
         .fileEntity(fileEntity)
         .ctfFlagEntity(new ArrayList<>())
+        .maxSubmitCount(maxSubmitCount)
         .build();
   }
 
@@ -83,6 +84,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .dynamicInfo(dynamicInfo)
         .remainedSubmitCount(getVirtualTeamFlag(challenge).getRemainedSubmitCount())
         .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime())
+        .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }
 

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -83,7 +83,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .file(file)
         .dynamicInfo(dynamicInfo)
         .remainedSubmitCount(getVirtualTeamFlag(challenge).getRemainedSubmitCount())
-        .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime().orElseGet(null))
+        .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime())
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -12,6 +12,7 @@ import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
+import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.util.dto.FileDto;
 import keeper.project.homepage.util.entity.FileEntity;
@@ -31,7 +32,6 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
 
   private Boolean isSolvable;
   private String flag;
-  private Long submitCount;
   protected CtfChallengeTypeDto type;
 
   @JsonProperty(access = Access.READ_ONLY)
@@ -74,14 +74,18 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .contestId(challenge.getCtfContestEntity().getId())
         .category(category)
         .type(type)
-        .flag(challenge.getCtfFlagEntity().get(0).getContent())
+        .flag(getVirtualTeamFlag(challenge).getContent())
         .isSolvable(challenge.getIsSolvable())
         .registerTime(challenge.getRegisterTime())
         .creatorName(challenge.getCreator().getNickName())
         .score(challenge.getScore())
         .file(file)
         .dynamicInfo(dynamicInfo)
-        .submitCount(challenge.getCtfFlagEntity().get(0).getRemainingSubmitCount())
+        .remainingSubmitCount(getVirtualTeamFlag(challenge).getRemainingSubmitCount())
         .build();
+  }
+
+  private static CtfFlagEntity getVirtualTeamFlag(CtfChallengeEntity challenge) {
+    return challenge.getCtfFlagEntity().get(0);
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -8,13 +8,13 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import keeper.project.homepage.util.entity.FileEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.util.dto.FileDto;
+import keeper.project.homepage.util.entity.FileEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +31,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
 
   private Boolean isSolvable;
   private String flag;
+  private Long submitCount;
   protected CtfChallengeTypeDto type;
 
   @JsonProperty(access = Access.READ_ONLY)
@@ -80,6 +81,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .score(challenge.getScore())
         .file(file)
         .dynamicInfo(dynamicInfo)
+        .submitCount(challenge.getCtfFlagEntity().get(0).getRemainingSubmitCount())
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -88,7 +88,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .build();
   }
 
-  private static CtfFlagEntity getVirtualTeamFlag(CtfChallengeEntity challenge) {
+  static CtfFlagEntity getVirtualTeamFlag(CtfChallengeEntity challenge) {
     return challenge.getCtfFlagEntity().get(0);
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -83,7 +83,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .file(file)
         .dynamicInfo(dynamicInfo)
         .remainedSubmitCount(getVirtualTeamFlag(challenge).getRemainedSubmitCount())
-        .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime())
+        .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime().orElseGet(null))
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -81,7 +81,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .score(challenge.getScore())
         .file(file)
         .dynamicInfo(dynamicInfo)
-        .remainingSubmitCount(getVirtualTeamFlag(challenge).getRemainingSubmitCount())
+        .remainedSubmitCount(getVirtualTeamFlag(challenge).getRemainedSubmitCount())
         .build();
   }
 

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -49,7 +49,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .isSolved(isSolved)
         .file(file)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
-        .lastTryTime(ctfFlagEntity.getLastTryTime().orElseGet(null))
+        .lastTryTime(ctfFlagEntity.getLastTryTime())
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
+import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.util.dto.FileDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,7 +32,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
   protected FileDto file;
 
   public static CtfChallengeDto toDto(CtfChallengeEntity challenge, Long solvedTeamCount,
-      Boolean isSolved, Long remainedSubmitCount) {
+      Boolean isSolved, CtfFlagEntity ctfFlagEntity) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
     FileDto file = FileDto.toDto(challenge.getFileEntity());
@@ -47,7 +48,8 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .solvedTeamCount(solvedTeamCount)
         .isSolved(isSolved)
         .file(file)
-        .remainedSubmitCount(remainedSubmitCount)
+        .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
+        .lastTryTime(ctfFlagEntity.getLastTryTime())
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -49,7 +49,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .isSolved(isSolved)
         .file(file)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
-        .lastTryTime(ctfFlagEntity.getLastTryTime())
+        .lastTryTime(ctfFlagEntity.getLastTryTime().orElseGet(null))
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -31,7 +31,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
   protected FileDto file;
 
   public static CtfChallengeDto toDto(CtfChallengeEntity challenge, Long solvedTeamCount,
-      Boolean isSolved, Long remainingSubmitCount) {
+      Boolean isSolved, Long remainedSubmitCount) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
     FileDto file = FileDto.toDto(challenge.getFileEntity());
@@ -47,7 +47,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .solvedTeamCount(solvedTeamCount)
         .isSolved(isSolved)
         .file(file)
-        .remainingSubmitCount(remainingSubmitCount)
+        .remainedSubmitCount(remainedSubmitCount)
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -50,6 +50,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .file(file)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
         .lastTryTime(ctfFlagEntity.getLastTryTime())
+        .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -31,7 +31,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
   protected FileDto file;
 
   public static CtfChallengeDto toDto(CtfChallengeEntity challenge, Long solvedTeamCount,
-      Boolean isSolved) {
+      Boolean isSolved, Long remainingSubmitCount) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
     FileDto file = FileDto.toDto(challenge.getFileEntity());
@@ -47,6 +47,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .solvedTeamCount(solvedTeamCount)
         .isSolved(isSolved)
         .file(file)
+        .remainingSubmitCount(remainingSubmitCount)
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -49,7 +49,7 @@ public class CtfCommonChallengeDto {
         .score(challenge.getScore())
         .isSolved(isSolved)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
-        .lastTryTime(ctfFlagEntity.getLastTryTime().orElseGet(null))
+        .lastTryTime(ctfFlagEntity.getLastTryTime())
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import java.time.LocalDateTime;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
+import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,12 +28,14 @@ public class CtfCommonChallengeDto {
   protected Long remainedSubmitCount;
 
   @JsonProperty(access = Access.READ_ONLY)
+  protected LocalDateTime lastTryTime;
+  @JsonProperty(access = Access.READ_ONLY)
   protected Long challengeId;
   @JsonProperty(access = Access.READ_ONLY)
   protected Boolean isSolved;
 
   public static CtfCommonChallengeDto toDto(CtfChallengeEntity challenge, Boolean isSolved,
-      Long remainedSubmitCount) {
+      CtfFlagEntity ctfFlagEntity) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
 
@@ -42,7 +46,8 @@ public class CtfCommonChallengeDto {
         .category(category)
         .score(challenge.getScore())
         .isSolved(isSolved)
-        .remainedSubmitCount(remainedSubmitCount)
+        .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
+        .lastTryTime(ctfFlagEntity.getLastTryTime())
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -49,7 +49,7 @@ public class CtfCommonChallengeDto {
         .score(challenge.getScore())
         .isSolved(isSolved)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
-        .lastTryTime(ctfFlagEntity.getLastTryTime())
+        .lastTryTime(ctfFlagEntity.getLastTryTime().orElseGet(null))
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -25,8 +25,10 @@ public class CtfCommonChallengeDto {
   protected Long score;
   protected CtfChallengeCategoryDto category;
   protected Long contestId;
-  protected Long remainedSubmitCount;
+  protected Long maxSubmitCount;
 
+  @JsonProperty(access = Access.READ_ONLY)
+  protected Long remainedSubmitCount;
   @JsonProperty(access = Access.READ_ONLY)
   protected LocalDateTime lastTryTime;
   @JsonProperty(access = Access.READ_ONLY)
@@ -48,6 +50,7 @@ public class CtfCommonChallengeDto {
         .isSolved(isSolved)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
         .lastTryTime(ctfFlagEntity.getLastTryTime())
+        .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -23,13 +23,15 @@ public class CtfCommonChallengeDto {
   protected Long score;
   protected CtfChallengeCategoryDto category;
   protected Long contestId;
+  protected Long remainingSubmitCount;
 
   @JsonProperty(access = Access.READ_ONLY)
   protected Long challengeId;
   @JsonProperty(access = Access.READ_ONLY)
   protected Boolean isSolved;
 
-  public static CtfCommonChallengeDto toDto(CtfChallengeEntity challenge, Boolean isSolved) {
+  public static CtfCommonChallengeDto toDto(CtfChallengeEntity challenge, Boolean isSolved,
+      Long remainingSubmitCount) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
 
@@ -40,6 +42,7 @@ public class CtfCommonChallengeDto {
         .category(category)
         .score(challenge.getScore())
         .isSolved(isSolved)
+        .remainingSubmitCount(remainingSubmitCount)
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -23,7 +23,7 @@ public class CtfCommonChallengeDto {
   protected Long score;
   protected CtfChallengeCategoryDto category;
   protected Long contestId;
-  protected Long remainingSubmitCount;
+  protected Long remainedSubmitCount;
 
   @JsonProperty(access = Access.READ_ONLY)
   protected Long challengeId;
@@ -31,7 +31,7 @@ public class CtfCommonChallengeDto {
   protected Boolean isSolved;
 
   public static CtfCommonChallengeDto toDto(CtfChallengeEntity challenge, Boolean isSolved,
-      Long remainingSubmitCount) {
+      Long remainedSubmitCount) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
 
@@ -42,7 +42,7 @@ public class CtfCommonChallengeDto {
         .category(category)
         .score(challenge.getScore())
         .isSolved(isSolved)
-        .remainingSubmitCount(remainingSubmitCount)
+        .remainedSubmitCount(remainedSubmitCount)
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfTeamDetailDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfTeamDetailDto.java
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import java.time.LocalDateTime;
 import java.util.List;
-import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfTeamEntity;
+import keeper.project.homepage.ctf.service.CtfTeamService.TeamSolvedChallengeInfo;
 import keeper.project.homepage.member.dto.CommonMemberDto;
 import keeper.project.homepage.member.entity.MemberEntity;
 import lombok.AllArgsConstructor;
@@ -34,7 +34,7 @@ public class CtfTeamDetailDto extends CtfTeamDto {
   List<CtfCommonChallengeDto> solvedChallengeList;
 
   public static CtfTeamDetailDto toDto(CtfTeamEntity team,
-      List<CtfChallengeEntity> solvedChallengeList) {
+      List<TeamSolvedChallengeInfo> solvedChallengeList) {
     return CtfTeamDetailDto.builder()
         .id(team.getId())
         .name(team.getName())
@@ -50,9 +50,15 @@ public class CtfTeamDetailDto extends CtfTeamDto {
                 .toList())
         .solvedChallengeList(
             solvedChallengeList.stream()
-                .map(challenge -> CtfCommonChallengeDto.toDto(challenge, true, 0L))
+                .map(CtfTeamDetailDto::getCtfCommonChallengeDto)
                 .toList())
         .build();
+  }
+
+  private static CtfCommonChallengeDto getCtfCommonChallengeDto(
+      TeamSolvedChallengeInfo challengeInfo) {
+    return CtfCommonChallengeDto.toDto(challengeInfo.getChallengeEntity(), true,
+        challengeInfo.getCtfFlagEntity());
   }
 
   public CtfTeamEntity toEntity(CtfContestEntity contest, MemberEntity creator) {

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfTeamDetailDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfTeamDetailDto.java
@@ -50,7 +50,8 @@ public class CtfTeamDetailDto extends CtfTeamDto {
                 .toList())
         .solvedChallengeList(
             solvedChallengeList.stream()
-                .map(challenge -> CtfCommonChallengeDto.toDto(challenge, true)).toList())
+                .map(challenge -> CtfCommonChallengeDto.toDto(challenge, true, 0L))
+                .toList())
         .build();
   }
 

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeEntity.java
@@ -16,8 +16,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
-import keeper.project.homepage.util.entity.FileEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
+import keeper.project.homepage.util.entity.FileEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,6 +64,9 @@ public class CtfChallengeEntity {
   @Column(nullable = false)
   @Setter
   Long score;
+
+  @Column(name = "max_submit_count", nullable = false)
+  Long maxSubmitCount;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "contest_id", nullable = false)

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -15,12 +15,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@DynamicUpdate
+@DynamicInsert
 @Table(name = "ctf_flag")
 public class CtfFlagEntity {
 

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -1,7 +1,6 @@
 package keeper.project.homepage.ctf.entity;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -69,7 +68,8 @@ public class CtfFlagEntity {
     --remainedSubmitCount;
   }
 
-  public Optional<LocalDateTime> getLastTryTime() {
-    return Optional.ofNullable(lastTryTime);
+  public boolean isTooFastRetry(final long maxRetrySeconds) {
+    return lastTryTime != null &&
+        lastTryTime.isAfter(LocalDateTime.now().minusSeconds(maxRetrySeconds));
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -51,20 +51,20 @@ public class CtfFlagEntity {
   @Setter
   LocalDateTime solvedTime;
 
-  @Column(name = "last_submit_time")
-  LocalDateTime lastSubmitTime;
+  @Column(name = "last_try_time")
+  LocalDateTime lastTryTime;
 
-  @Column(name = "remaining_submit_count")
-  Long remainingSubmitCount;
+  @Column(name = "remained_submit_count")
+  Long remainedSubmitCount;
 
-  public void updateLastSubmitTime() {
-    lastSubmitTime = LocalDateTime.now();
+  public void updateLastTryTime() {
+    lastTryTime = LocalDateTime.now();
   }
 
   public void decreaseSubmitCount() {
-    if (remainingSubmitCount <= 0) {
+    if (remainedSubmitCount <= 0) {
       throw new IllegalStateException("제출 횟수가 0이하이기 때문에 제출 횟수를 감소시킬 수 없습니다.");
     }
-    --remainingSubmitCount;
+    --remainedSubmitCount;
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -1,6 +1,7 @@
 package keeper.project.homepage.ctf.entity;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -66,5 +67,9 @@ public class CtfFlagEntity {
       throw new IllegalStateException("제출 횟수를 모두 소진하셨기 때문에 제출 횟수를 감소시킬 수 없습니다.");
     }
     --remainedSubmitCount;
+  }
+
+  public Optional<LocalDateTime> getLastTryTime() {
+    return Optional.ofNullable(lastTryTime);
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -46,4 +46,21 @@ public class CtfFlagEntity {
   @Column(name = "solved_time")
   @Setter
   LocalDateTime solvedTime;
+
+  @Column(name = "last_submit_time")
+  LocalDateTime lastSubmitTime;
+
+  @Column(name = "remaining_submit_count")
+  Long remainingSubmitCount;
+
+  public void updateLastSubmitTime() {
+    lastSubmitTime = LocalDateTime.now();
+  }
+
+  public void decreaseSubmitCount() {
+    if (remainingSubmitCount <= 0) {
+      throw new IllegalStateException("제출 횟수가 0이하이기 때문에 제출 횟수를 감소시킬 수 없습니다.");
+    }
+    --remainingSubmitCount;
+  }
 }

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -63,7 +63,7 @@ public class CtfFlagEntity {
 
   public void decreaseSubmitCount() {
     if (remainedSubmitCount <= 0) {
-      throw new IllegalStateException("제출 횟수가 0이하이기 때문에 제출 횟수를 감소시킬 수 없습니다.");
+      throw new IllegalStateException("제출 횟수를 모두 소진하셨기 때문에 제출 횟수를 감소시킬 수 없습니다.");
     }
     --remainedSubmitCount;
   }

--- a/src/main/java/keeper/project/homepage/ctf/exception/CtfExceptionAdvice.java
+++ b/src/main/java/keeper/project/homepage/ctf/exception/CtfExceptionAdvice.java
@@ -72,4 +72,13 @@ public class CtfExceptionAdvice {
         e.getMessage() == null ? exceptionUtil.getMessage("ctfSubmitCountNotEnough.msg")
             : e.getMessage());
   }
+
+  @ExceptionHandler(CustomTooFastRetryException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  protected CommonResult ctfTooFastRetry(CustomTooFastRetryException e) {
+    return responseService.getFailResult(
+        Integer.parseInt(exceptionUtil.getMessage("ctfTooFastRetry.code")),
+        e.getMessage() == null ? exceptionUtil.getMessage("ctfTooFastRetry.msg",
+            new Object[]{e.getRetrySeconds()}) : e.getMessage());
+  }
 }

--- a/src/main/java/keeper/project/homepage/ctf/exception/CtfExceptionAdvice.java
+++ b/src/main/java/keeper/project/homepage/ctf/exception/CtfExceptionAdvice.java
@@ -63,4 +63,13 @@ public class CtfExceptionAdvice {
         Integer.parseInt(exceptionUtil.getMessage("ctfTeamNotFound.code")),
         e.getMessage() == null ? exceptionUtil.getMessage("ctfTeamNotFound.msg") : e.getMessage());
   }
+
+  @ExceptionHandler(CustomSubmitCountNotEnoughException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  protected CommonResult ctfSubmitCountNotEnough(CustomSubmitCountNotEnoughException e) {
+    return responseService.getFailResult(
+        Integer.parseInt(exceptionUtil.getMessage("ctfSubmitCountNotEnough.code")),
+        e.getMessage() == null ? exceptionUtil.getMessage("ctfSubmitCountNotEnough.msg")
+            : e.getMessage());
+  }
 }

--- a/src/main/java/keeper/project/homepage/ctf/exception/CustomSubmitCountNotEnoughException.java
+++ b/src/main/java/keeper/project/homepage/ctf/exception/CustomSubmitCountNotEnoughException.java
@@ -1,0 +1,17 @@
+package keeper.project.homepage.ctf.exception;
+
+public class CustomSubmitCountNotEnoughException extends RuntimeException {
+
+  public CustomSubmitCountNotEnoughException(String msg, Throwable t) {
+    super(msg, t);
+  }
+
+  public CustomSubmitCountNotEnoughException(String msg) {
+    super(msg);
+  }
+
+  public CustomSubmitCountNotEnoughException() {
+    super();
+  }
+
+}

--- a/src/main/java/keeper/project/homepage/ctf/exception/CustomSubmitCountNotEnoughException.java
+++ b/src/main/java/keeper/project/homepage/ctf/exception/CustomSubmitCountNotEnoughException.java
@@ -10,6 +10,10 @@ public class CustomSubmitCountNotEnoughException extends RuntimeException {
     super(msg);
   }
 
+  public CustomSubmitCountNotEnoughException(Throwable cause) {
+    super(cause);
+  }
+
   public CustomSubmitCountNotEnoughException() {
     super();
   }

--- a/src/main/java/keeper/project/homepage/ctf/exception/CustomTooFastRetryException.java
+++ b/src/main/java/keeper/project/homepage/ctf/exception/CustomTooFastRetryException.java
@@ -1,0 +1,23 @@
+package keeper.project.homepage.ctf.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomTooFastRetryException extends RuntimeException {
+
+  private long retrySeconds;
+
+  public CustomTooFastRetryException(String msg, Throwable t) {
+    super(msg, t);
+  }
+
+  public CustomTooFastRetryException(String msg) {
+    super(msg);
+  }
+
+  public CustomTooFastRetryException(long retrySeconds) {
+    super();
+    this.retrySeconds = retrySeconds;
+  }
+
+}

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -116,7 +116,7 @@ public class CtfAdminService {
       trySetDynamicInfoInChallenge(newChallenge, challengeAdminDto);
     }
     setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge,
-        challengeAdminDto.getRemainedSubmitCount());
+        challengeAdminDto.getMaxSubmitCount());
     return CtfChallengeAdminDto.toDto(newChallenge);
   }
 

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -1,5 +1,6 @@
 package keeper.project.homepage.ctf.service;
 
+import static java.time.LocalDateTime.now;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_CONTEST_ID;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLEM_ID;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_TEAM_ID;
@@ -298,6 +299,7 @@ public class CtfAdminService {
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
           .remainedSubmitCount(maxSubmitCount)
+          .lastTryTime(now())
           .build();
       ctfFlagRepository.save(flagEntity);
       challenge.getCtfFlagEntity().add(flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -115,7 +115,7 @@ public class CtfAdminService {
       trySetDynamicInfoInChallenge(newChallenge, challengeAdminDto);
     }
     setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge,
-        challengeAdminDto.getRemainingSubmitCount());
+        challengeAdminDto.getRemainedSubmitCount());
     return CtfChallengeAdminDto.toDto(newChallenge);
   }
 
@@ -297,7 +297,7 @@ public class CtfAdminService {
           .ctfTeamEntity(ctfTeam)
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
-          .remainingSubmitCount(maxSubmitCount)
+          .remainedSubmitCount(maxSubmitCount)
           .build();
       ctfFlagRepository.save(flagEntity);
       challenge.getCtfFlagEntity().add(flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -1,11 +1,11 @@
 package keeper.project.homepage.ctf.service;
 
-import static java.time.LocalDateTime.now;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_CONTEST_ID;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLEM_ID;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_TEAM_ID;
 
 import java.nio.file.AccessDeniedException;
+import java.time.LocalDateTime;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
@@ -299,7 +299,7 @@ public class CtfAdminService {
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
           .remainedSubmitCount(maxSubmitCount)
-          .lastTryTime(now())
+          .lastTryTime(LocalDateTime.now())
           .build();
       ctfFlagRepository.save(flagEntity);
       challenge.getCtfFlagEntity().add(flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -114,7 +114,8 @@ public class CtfAdminService {
     if (ctfUtilService.isTypeDynamic(newChallenge)) {
       trySetDynamicInfoInChallenge(newChallenge, challengeAdminDto);
     }
-    setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge, challengeAdminDto.getSubmitCount());
+    setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge,
+        challengeAdminDto.getRemainingSubmitCount());
     return CtfChallengeAdminDto.toDto(newChallenge);
   }
 
@@ -286,7 +287,7 @@ public class CtfAdminService {
     return dynamicInfo.toEntity(challenge);
   }
 
-  private void setFlagAllTeam(String flag, CtfChallengeEntity challenge, long submitCount) {
+  private void setFlagAllTeam(String flag, CtfChallengeEntity challenge, long maxSubmitCount) {
     // team이 하나도 없을 때 flag가 유실되는 것을 방지하기 위해 VIRTUAL TEAM을 이용해 flag를 저장합니다.
     List<CtfTeamEntity> allCtfTeamList = ctfTeamRepository
         .findAllByIdOrCtfContestEntityId(VIRTUAL_TEAM_ID, getCtfId(challenge));
@@ -296,7 +297,7 @@ public class CtfAdminService {
           .ctfTeamEntity(ctfTeam)
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
-          .remainingSubmitCount(submitCount)
+          .remainingSubmitCount(maxSubmitCount)
           .build();
       ctfFlagRepository.save(flagEntity);
       challenge.getCtfFlagEntity().add(flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -114,7 +114,7 @@ public class CtfAdminService {
     if (ctfUtilService.isTypeDynamic(newChallenge)) {
       trySetDynamicInfoInChallenge(newChallenge, challengeAdminDto);
     }
-    setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge);
+    setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge, challengeAdminDto.getSubmitCount());
     return CtfChallengeAdminDto.toDto(newChallenge);
   }
 
@@ -286,7 +286,7 @@ public class CtfAdminService {
     return dynamicInfo.toEntity(challenge);
   }
 
-  private void setFlagAllTeam(String flag, CtfChallengeEntity challenge) {
+  private void setFlagAllTeam(String flag, CtfChallengeEntity challenge, long submitCount) {
     // team이 하나도 없을 때 flag가 유실되는 것을 방지하기 위해 VIRTUAL TEAM을 이용해 flag를 저장합니다.
     List<CtfTeamEntity> allCtfTeamList = ctfTeamRepository
         .findAllByIdOrCtfContestEntityId(VIRTUAL_TEAM_ID, getCtfId(challenge));
@@ -296,6 +296,7 @@ public class CtfAdminService {
           .ctfTeamEntity(ctfTeam)
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
+          .remainingSubmitCount(submitCount)
           .build();
       ctfFlagRepository.save(flagEntity);
       challenge.getCtfFlagEntity().add(flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -61,7 +61,9 @@ public class CtfChallengeService {
         .map(solvableChallenge -> {
           CtfFlagEntity ctfFlagEntity = getCtfFlagEntity(solvableChallenge, myTeam);
           Boolean isMyTeamSolved = isAlreadySolved(ctfFlagEntity);
-          return CtfCommonChallengeDto.toDto(solvableChallenge, isMyTeamSolved);
+          Long remainingSubmitCount = ctfFlagEntity.getRemainingSubmitCount();
+          return CtfCommonChallengeDto.toDto(solvableChallenge, isMyTeamSolved,
+              remainingSubmitCount);
         }).toList();
   }
 
@@ -132,8 +134,11 @@ public class CtfChallengeService {
     Long solvedTeamCount = getSolvedTeamCount(probId);
     CtfTeamEntity myTeam = getTeamEntity(getCtfIdByChallenge(challengeEntity),
         authService.getMemberIdByJWT());
-    Boolean isAlreadySolved = isAlreadySolved(getCtfFlagEntity(challengeEntity, myTeam));
-    return CtfChallengeDto.toDto(challengeEntity, solvedTeamCount, isAlreadySolved);
+    CtfFlagEntity ctfFlagEntity = getCtfFlagEntity(challengeEntity, myTeam);
+    Boolean isAlreadySolved = isAlreadySolved(ctfFlagEntity);
+    Long remainingSubmitCount = ctfFlagEntity.getRemainingSubmitCount();
+    return CtfChallengeDto.toDto(challengeEntity, solvedTeamCount, isAlreadySolved,
+        remainingSubmitCount);
   }
 
   @Transactional

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -4,7 +4,6 @@ import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLE
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import keeper.project.homepage.ctf.dto.CtfChallengeDto;
 import keeper.project.homepage.ctf.dto.CtfCommonChallengeDto;
 import keeper.project.homepage.ctf.dto.CtfFlagDto;
@@ -88,7 +87,7 @@ public class CtfChallengeService {
     Long submitterId = authService.getMemberIdByJWT();
     CtfTeamEntity submitTeam = getTeamEntity(getCtfIdByChallenge(submitChallenge), submitterId);
     CtfFlagEntity flagEntity = getFlagEntity(probId, submitTeam);
-    if (isTooFastRetry(flagEntity)) {
+    if (flagEntity.isTooFastRetry(RETRY_SECONDS)) {
       throw new CustomTooFastRetryException(RETRY_SECONDS);
     }
     flagEntity.updateLastTryTime();
@@ -107,12 +106,6 @@ public class CtfChallengeService {
       }
     }
     return CtfFlagDto.toDto(flagEntity);
-  }
-
-  private static boolean isTooFastRetry(CtfFlagEntity flagEntity) {
-    Optional<LocalDateTime> lastTryTime = flagEntity.getLastTryTime();
-    return lastTryTime.isPresent() &&
-        lastTryTime.get().isAfter(LocalDateTime.now().minusSeconds(RETRY_SECONDS));
   }
 
   private static void tryDecreaseSubmitCount(CtfFlagEntity flagEntity) {

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -62,9 +62,9 @@ public class CtfChallengeService {
         .map(solvableChallenge -> {
           CtfFlagEntity ctfFlagEntity = getCtfFlagEntity(solvableChallenge, myTeam);
           Boolean isMyTeamSolved = isAlreadySolved(ctfFlagEntity);
-          Long remainingSubmitCount = ctfFlagEntity.getRemainingSubmitCount();
+          Long remainedSubmitCount = ctfFlagEntity.getRemainedSubmitCount();
           return CtfCommonChallengeDto.toDto(solvableChallenge, isMyTeamSolved,
-              remainingSubmitCount);
+              remainedSubmitCount);
         }).toList();
   }
 
@@ -85,7 +85,7 @@ public class CtfChallengeService {
     Long submitterId = authService.getMemberIdByJWT();
     CtfTeamEntity submitTeam = getTeamEntity(getCtfIdByChallenge(submitChallenge), submitterId);
     CtfFlagEntity flagEntity = getFlagEntity(probId, submitTeam);
-    if (flagEntity.getRemainingSubmitCount() <= 0) {
+    if (flagEntity.getRemainedSubmitCount() <= 0) {
       throw new CustomSubmitCountNotEnoughException();
     }
     flagEntity.decreaseSubmitCount();
@@ -141,9 +141,9 @@ public class CtfChallengeService {
         authService.getMemberIdByJWT());
     CtfFlagEntity ctfFlagEntity = getCtfFlagEntity(challengeEntity, myTeam);
     Boolean isAlreadySolved = isAlreadySolved(ctfFlagEntity);
-    Long remainingSubmitCount = ctfFlagEntity.getRemainingSubmitCount();
+    Long remainedSubmitCount = ctfFlagEntity.getRemainedSubmitCount();
     return CtfChallengeDto.toDto(challengeEntity, solvedTeamCount, isAlreadySolved,
-        remainingSubmitCount);
+        remainedSubmitCount);
   }
 
   @Transactional

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -91,11 +91,8 @@ public class CtfChallengeService {
         flagEntity.getLastTryTime().isAfter(LocalDateTime.now().minusSeconds(RETRY_SECONDS))) {
       throw new CustomTooFastRetryException(RETRY_SECONDS);
     }
-    if (flagEntity.getRemainedSubmitCount() <= 0) {
-      throw new CustomSubmitCountNotEnoughException();
-    }
     flagEntity.updateLastTryTime();
-    flagEntity.decreaseSubmitCount();
+    tryDecreaseSubmitCount(flagEntity);
     // 이미 맞췄으면 제출한 flag 정답 유무만 체크하고 DB 갱신 안함.
     if (isAlreadySolved(flagEntity)) {
       setSubmitFlagIsCorrect(submitFlag, flagEntity);
@@ -110,6 +107,14 @@ public class CtfChallengeService {
       }
     }
     return CtfFlagDto.toDto(flagEntity);
+  }
+
+  private static void tryDecreaseSubmitCount(CtfFlagEntity flagEntity) {
+    try {
+      flagEntity.decreaseSubmitCount();
+    } catch (IllegalStateException e) {
+      throw new CustomSubmitCountNotEnoughException(e.getCause());
+    }
   }
 
   private void setSubmitFlagIsCorrect(CtfFlagDto submitFlag, CtfFlagEntity flagEntity) {

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -14,6 +14,7 @@ import keeper.project.homepage.ctf.entity.CtfSubmitLogEntity;
 import keeper.project.homepage.ctf.entity.CtfTeamEntity;
 import keeper.project.homepage.ctf.exception.CustomContestNotFoundException;
 import keeper.project.homepage.ctf.exception.CustomCtfChallengeNotFoundException;
+import keeper.project.homepage.ctf.exception.CustomSubmitCountNotEnoughException;
 import keeper.project.homepage.ctf.repository.CtfChallengeRepository;
 import keeper.project.homepage.ctf.repository.CtfContestRepository;
 import keeper.project.homepage.ctf.repository.CtfFlagRepository;
@@ -84,6 +85,10 @@ public class CtfChallengeService {
     Long submitterId = authService.getMemberIdByJWT();
     CtfTeamEntity submitTeam = getTeamEntity(getCtfIdByChallenge(submitChallenge), submitterId);
     CtfFlagEntity flagEntity = getFlagEntity(probId, submitTeam);
+    if (flagEntity.getRemainingSubmitCount() <= 0) {
+      throw new CustomSubmitCountNotEnoughException();
+    }
+    flagEntity.decreaseSubmitCount();
     // 이미 맞췄으면 제출한 flag 정답 유무만 체크하고 DB 갱신 안함.
     if (isAlreadySolved(flagEntity)) {
       setSubmitFlagIsCorrect(submitFlag, flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -37,7 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CtfChallengeService {
 
-  static final long RETRY_SECONDS = 5;
+  public static final long RETRY_SECONDS = 5;
 
   private final CtfChallengeRepository challengeRepository;
   private final CtfTeamHasMemberRepository teamHasMemberRepository;
@@ -65,9 +65,8 @@ public class CtfChallengeService {
         .map(solvableChallenge -> {
           CtfFlagEntity ctfFlagEntity = getCtfFlagEntity(solvableChallenge, myTeam);
           Boolean isMyTeamSolved = isAlreadySolved(ctfFlagEntity);
-          Long remainedSubmitCount = ctfFlagEntity.getRemainedSubmitCount();
           return CtfCommonChallengeDto.toDto(solvableChallenge, isMyTeamSolved,
-              remainedSubmitCount);
+              ctfFlagEntity);
         }).toList();
   }
 
@@ -88,7 +87,8 @@ public class CtfChallengeService {
     Long submitterId = authService.getMemberIdByJWT();
     CtfTeamEntity submitTeam = getTeamEntity(getCtfIdByChallenge(submitChallenge), submitterId);
     CtfFlagEntity flagEntity = getFlagEntity(probId, submitTeam);
-    if (flagEntity.getLastTryTime().isAfter(LocalDateTime.now().minusSeconds(RETRY_SECONDS))) {
+    if (flagEntity.getLastTryTime() != null &&
+        flagEntity.getLastTryTime().isAfter(LocalDateTime.now().minusSeconds(RETRY_SECONDS))) {
       throw new CustomTooFastRetryException(RETRY_SECONDS);
     }
     if (flagEntity.getRemainedSubmitCount() <= 0) {
@@ -148,9 +148,8 @@ public class CtfChallengeService {
         authService.getMemberIdByJWT());
     CtfFlagEntity ctfFlagEntity = getCtfFlagEntity(challengeEntity, myTeam);
     Boolean isAlreadySolved = isAlreadySolved(ctfFlagEntity);
-    Long remainedSubmitCount = ctfFlagEntity.getRemainedSubmitCount();
     return CtfChallengeDto.toDto(challengeEntity, solvedTeamCount, isAlreadySolved,
-        remainedSubmitCount);
+        ctfFlagEntity);
   }
 
   @Transactional

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfTeamService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfTeamService.java
@@ -1,5 +1,6 @@
 package keeper.project.homepage.ctf.service;
 
+import static java.time.LocalDateTime.now;
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_CONTEST_ID;
 
 import java.time.LocalDateTime;
@@ -60,7 +61,7 @@ public class CtfTeamService {
     Long contestId = ctfTeamDetailDto.getContestId();
     MemberEntity creator = getMemberEntityByJWT();
     CtfContestEntity contest = getContestEntity(contestId);
-    ctfTeamDetailDto.setRegisterTime(LocalDateTime.now());
+    ctfTeamDetailDto.setRegisterTime(now());
     CtfTeamEntity newTeamEntity = saveTeam(ctfTeamDetailDto.toEntity(contest, creator));
     return newTeamEntity;
   }
@@ -245,6 +246,7 @@ public class CtfTeamService {
           .ctfTeamEntity(newTeamEntity)
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
+          .lastTryTime(now())
           .build();
       flagRepository.save(flagEntity);
     });

--- a/src/main/resources/exception.properties
+++ b/src/main/resources/exception.properties
@@ -106,6 +106,8 @@ ctfChallengeNotFound.code=-13003
 ctfChallengeNotFound.msg=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 CTF \uBB38\uC81C\uC785\uB2C8\uB2E4.
 ctfTeamNotFound.code=-13004
 ctfTeamNotFound.msg=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uD300\uC785\uB2C8\uB2E4.
+ctfSubmitCountNotEnough.code=-13005
+ctfSubmitCountNotEnough.msg=\uC81C\uCD9C \uD69F\uC218\uB97C \uBAA8\uB450 \uC18C\uC9C4\uD558\uC168\uC2B5\uB2C8\uB2E4.
 # election 14000 ~ 14999
 electionNotFound.code=-14000
 electionNotFound.msg=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC120\uAC70\uC785\uB2C8\uB2E4.

--- a/src/main/resources/exception.properties
+++ b/src/main/resources/exception.properties
@@ -108,6 +108,8 @@ ctfTeamNotFound.code=-13004
 ctfTeamNotFound.msg=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uD300\uC785\uB2C8\uB2E4.
 ctfSubmitCountNotEnough.code=-13005
 ctfSubmitCountNotEnough.msg=\uC81C\uCD9C \uD69F\uC218\uB97C \uBAA8\uB450 \uC18C\uC9C4\uD558\uC168\uC2B5\uB2C8\uB2E4.
+ctfTooFastRetry.code=-13006
+ctfTooFastRetry.msg=\uB108\uBB34 \uBE68\uB9AC \uB2E4\uC2DC \uC81C\uCD9C\uD558\uC168\uC2B5\uB2C8\uB2E4. {0}\uCD08 \uB4A4\uC5D0 \uC81C\uCD9C\uD574\uC8FC\uC2DC\uAE38 \uBC14\uB78D\uB2C8\uB2E4.
 # election 14000 ~ 14999
 electionNotFound.code=-14000
 electionNotFound.msg=\uC874\uC7AC\uD558\uC9C0 \uC54A\uB294 \uC120\uAC70\uC785\uB2C8\uB2E4.

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -289,7 +289,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .score(score)
         .dynamicInfo(dynamicInfo)
         .flag(flag)
-        .submitCount(123L)
+        .remainingSubmitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")
@@ -328,7 +328,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                         "TYPE이 DYNAMIC일 경우 minScore")
                     .optional(),
                 fieldWithPath("flag").description("문제의 flag"),
-                fieldWithPath("submitCount").description("각 팀당 가능한 최대 제출 횟수")
+                fieldWithPath("remainingSubmitCount").description("각 팀당 가능한 최대 제출 횟수")
             ),
             responseFields(
                 generateChallengeAdminDtoResponseFields(ResponseType.SINGLE,
@@ -364,7 +364,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .creatorName(creator.getNickName())
         .score(score)
         .flag(flag)
-        .submitCount(123L)
+        .remainingSubmitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -289,7 +289,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .score(score)
         .dynamicInfo(dynamicInfo)
         .flag(flag)
-        .remainedSubmitCount(123L)
+        .maxSubmitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")
@@ -328,7 +328,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                         "TYPE이 DYNAMIC일 경우 minScore")
                     .optional(),
                 fieldWithPath("flag").description("문제의 flag"),
-                fieldWithPath("remainedSubmitCount").description("각 팀당 가능한 최대 제출 횟수")
+                fieldWithPath("maxSubmitCount").description("각 팀당 가능한 최대 제출 횟수")
             ),
             responseFields(
                 generateChallengeAdminDtoResponseFields(ResponseType.SINGLE,
@@ -364,7 +364,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .creatorName(creator.getNickName())
         .score(score)
         .flag(flag)
-        .remainedSubmitCount(123L)
+        .maxSubmitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -23,13 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import javax.persistence.EntityManager;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
+import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfContestAdminDto;
+import keeper.project.homepage.ctf.dto.CtfDynamicChallengeInfoDto;
 import keeper.project.homepage.ctf.dto.CtfProbMakerDto;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
-import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.ctf.entity.CtfSubmitLogEntity;
@@ -37,9 +37,6 @@ import keeper.project.homepage.ctf.entity.CtfTeamEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.member.entity.MemberHasMemberJobEntity;
 import keeper.project.homepage.member.entity.MemberJobEntity;
-import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
-import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
-import keeper.project.homepage.ctf.dto.CtfDynamicChallengeInfoDto;
 import keeper.project.homepage.util.service.CtfUtilService;
 import lombok.extern.log4j.Log4j2;
 import org.assertj.core.api.Assertions;
@@ -292,6 +289,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .score(score)
         .dynamicInfo(dynamicInfo)
         .flag(flag)
+        .submitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")
@@ -329,7 +327,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                 fieldWithPath("dynamicInfo.minScore").description(
                         "TYPE이 DYNAMIC일 경우 minScore")
                     .optional(),
-                fieldWithPath("flag").description("문제의 flag")
+                fieldWithPath("flag").description("문제의 flag"),
+                fieldWithPath("submitCount").description("각 팀당 가능한 최대 제출 횟수")
             ),
             responseFields(
                 generateChallengeAdminDtoResponseFields(ResponseType.SINGLE,
@@ -365,6 +364,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .creatorName(creator.getNickName())
         .score(score)
         .flag(flag)
+        .submitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -289,7 +289,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .score(score)
         .dynamicInfo(dynamicInfo)
         .flag(flag)
-        .remainingSubmitCount(123L)
+        .remainedSubmitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")
@@ -328,7 +328,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                         "TYPE이 DYNAMIC일 경우 minScore")
                     .optional(),
                 fieldWithPath("flag").description("문제의 flag"),
-                fieldWithPath("remainingSubmitCount").description("각 팀당 가능한 최대 제출 횟수")
+                fieldWithPath("remainedSubmitCount").description("각 팀당 가능한 최대 제출 횟수")
             ),
             responseFields(
                 generateChallengeAdminDtoResponseFields(ResponseType.SINGLE,
@@ -364,7 +364,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .creatorName(creator.getNickName())
         .score(score)
         .flag(flag)
-        .remainingSubmitCount(123L)
+        .remainedSubmitCount(123L)
         .build();
 
     mockMvc.perform(post("/v1/admin/ctf/prob")

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -105,14 +105,14 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
   }
 
   protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
-      Boolean isCorrect, Long remainingSubmitCount) {
+      Boolean isCorrect, Long remainedSubmitCount) {
     final long epochTime = System.nanoTime();
     CtfFlagEntity entity = CtfFlagEntity.builder()
         .content("flag_" + epochTime)
         .ctfTeamEntity(ctfTeam)
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(isCorrect)
-        .remainingSubmitCount(remainingSubmitCount)
+        .remainedSubmitCount(remainedSubmitCount)
         .build();
     ctfFlagRepository.save(entity);
     ctfChallenge.getCtfFlagEntity().add(entity);
@@ -273,7 +273,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".category.name").description("문제가 속한 카테고리의 이름"),
         fieldWithPath(prefix + ".score").description("문제의 점수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
-        fieldWithPath(prefix + ".remainingSubmitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id")
     ));
     if (addDescriptors.length > 0) {
@@ -301,7 +301,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".registerTime").description("문제의 등록 시간"),
         fieldWithPath(prefix + ".isSolvable").description("현재 풀 수 있는 지 여부"),
-        fieldWithPath(prefix + ".remainingSubmitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         subsectionWithPath(prefix + ".dynamicInfo").description("TYPE이 STANDARD일 경우 null")
             .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
@@ -341,7 +341,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".solvedTeamCount").description("푼 팀 수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
-        fieldWithPath(prefix + ".remainingSubmitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
     ));
     if (type.equals(ResponseType.PAGE)) {

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -1,5 +1,6 @@
 package keeper.project.homepage.ctf.controller;
 
+import static keeper.project.homepage.ctf.service.CtfChallengeService.RETRY_SECONDS;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 
@@ -287,6 +288,8 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".score").description("문제의 점수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
+            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. "),
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id")
     ));
     if (addDescriptors.length > 0) {
@@ -315,6 +318,8 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".registerTime").description("문제의 등록 시간"),
         fieldWithPath(prefix + ".isSolvable").description("현재 풀 수 있는 지 여부"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
+            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다."),
         subsectionWithPath(prefix + ".dynamicInfo").description("TYPE이 STANDARD일 경우 null")
             .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
@@ -355,6 +360,8 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".solvedTeamCount").description("푼 팀 수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
+            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다."),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
     ));
     if (type.equals(ResponseType.PAGE)) {

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -105,18 +105,23 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
   }
 
   protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
-      Boolean isCorrect) {
+      Boolean isCorrect, Long remainingSubmitCount) {
     final long epochTime = System.nanoTime();
     CtfFlagEntity entity = CtfFlagEntity.builder()
         .content("flag_" + epochTime)
         .ctfTeamEntity(ctfTeam)
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(isCorrect)
-        .remainingSubmitCount(123L)
+        .remainingSubmitCount(remainingSubmitCount)
         .build();
     ctfFlagRepository.save(entity);
     ctfChallenge.getCtfFlagEntity().add(entity);
     return entity;
+  }
+
+  protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
+      Boolean isCorrect) {
+    return generateCtfFlag(ctfTeam, ctfChallenge, isCorrect, 123L);
   }
 
   protected CtfSubmitLogEntity generateCtfSubmitLog(CtfTeamEntity ctfTeam, MemberEntity submitter,

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -105,7 +105,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
   }
 
   protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
-      Boolean isCorrect, Long remainedSubmitCount) {
+      Boolean isCorrect, Long remainedSubmitCount, LocalDateTime lastTryTime) {
     final long epochTime = System.nanoTime();
     CtfFlagEntity entity = CtfFlagEntity.builder()
         .content("flag_" + epochTime)
@@ -113,6 +113,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(isCorrect)
         .remainedSubmitCount(remainedSubmitCount)
+        .lastTryTime(lastTryTime)
         .build();
     ctfFlagRepository.save(entity);
     ctfChallenge.getCtfFlagEntity().add(entity);
@@ -121,7 +122,19 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
 
   protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
       Boolean isCorrect) {
-    return generateCtfFlag(ctfTeam, ctfChallenge, isCorrect, 123L);
+    return generateCtfFlag(ctfTeam, ctfChallenge, isCorrect, 123L,
+        LocalDateTime.now().minusDays(1));
+  }
+
+  protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
+      Boolean isCorrect, Long remainedSubmitCount) {
+    return generateCtfFlag(ctfTeam, ctfChallenge, isCorrect, remainedSubmitCount,
+        LocalDateTime.now().minusDays(1));
+  }
+
+  protected CtfFlagEntity generateCtfFlag(CtfTeamEntity ctfTeam, CtfChallengeEntity ctfChallenge,
+      Boolean isCorrect, LocalDateTime lastTryTime) {
+    return generateCtfFlag(ctfTeam, ctfChallenge, isCorrect, 123L, lastTryTime);
   }
 
   protected CtfSubmitLogEntity generateCtfSubmitLog(CtfTeamEntity ctfTeam, MemberEntity submitter,

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -268,6 +268,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".category.name").description("문제가 속한 카테고리의 이름"),
         fieldWithPath(prefix + ".score").description("문제의 점수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
+        fieldWithPath(prefix + ".remainingSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id")
     ));
     if (addDescriptors.length > 0) {
@@ -295,7 +296,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".registerTime").description("문제의 등록 시간"),
         fieldWithPath(prefix + ".isSolvable").description("현재 풀 수 있는 지 여부"),
-        fieldWithPath(prefix + ".submitCount").description("남은 제출 횟수"),
+        fieldWithPath(prefix + ".remainingSubmitCount").description("남은 제출 횟수"),
         subsectionWithPath(prefix + ".dynamicInfo").description("TYPE이 STANDARD일 경우 null")
             .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
@@ -335,6 +336,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".solvedTeamCount").description("푼 팀 수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
+        fieldWithPath(prefix + ".remainingSubmitCount").description("남은 제출 횟수"),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
     ));
     if (type.equals(ResponseType.PAGE)) {
@@ -496,7 +498,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".creatorId").description("team 생성자 Id"),
         fieldWithPath(prefix + ".contestId").description("team이 속한 contest Id"),
         subsectionWithPath(prefix + ".teamMembers").description("team에 속한 팀원 정보"),
-        subsectionWithPath(prefix + ".solvedChallengeList").description("team이 푼 문제들 정보")
+        subsectionWithPath(prefix + ".solvedChallengeList").description("team이 푼 문제들 정보 (푼 문제이므로 남은 제출 횟수가 0으로 표기되어 나갑니다.)")
     ));
     commonFields.addAll(generateTeamDtoResponseFields(type, success, code, msg));
     if (addDescriptors.length > 0) {

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -112,6 +112,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         .ctfTeamEntity(ctfTeam)
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(isCorrect)
+        .remainingSubmitCount(123L)
         .build();
     ctfFlagRepository.save(entity);
     ctfChallenge.getCtfFlagEntity().add(entity);
@@ -294,6 +295,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".registerTime").description("문제의 등록 시간"),
         fieldWithPath(prefix + ".isSolvable").description("현재 풀 수 있는 지 여부"),
+        fieldWithPath(prefix + ".submitCount").description("남은 제출 횟수"),
         subsectionWithPath(prefix + ".dynamicInfo").description("TYPE이 STANDARD일 경우 null")
             .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -201,6 +201,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         .score(score)
         .ctfContestEntity(ctfContestEntity)
         .ctfFlagEntity(new ArrayList<>())
+        .maxSubmitCount(100L)
         .build();
     ctfChallengeRepository.save(entity);
     return entity;
@@ -287,6 +288,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".category.name").description("문제가 속한 카테고리의 이름"),
         fieldWithPath(prefix + ".score").description("문제의 점수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
+        fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
             + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. "),
@@ -317,6 +319,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".registerTime").description("문제의 등록 시간"),
         fieldWithPath(prefix + ".isSolvable").description("현재 풀 수 있는 지 여부"),
+        fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
             + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다."),
@@ -359,6 +362,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),
         fieldWithPath(prefix + ".solvedTeamCount").description("푼 팀 수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
+        fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
             + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다."),

--- a/src/test/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDtoTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDtoTest.java
@@ -1,0 +1,34 @@
+package keeper.project.homepage.ctf.dto;
+
+import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLEM_ID;
+import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_TEAM_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import keeper.project.homepage.ctf.entity.CtfFlagEntity;
+import keeper.project.homepage.ctf.repository.CtfChallengeRepository;
+import keeper.project.homepage.ctf.repository.CtfFlagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CtfChallengeAdminDtoTest {
+
+  @Autowired
+  private CtfChallengeRepository challengeRepository;
+  @Autowired
+  private CtfFlagRepository flagRepository;
+
+  @Test
+  @DisplayName("Virtual Team Flag가 항상 존재하는지 테스트")
+  void hasVirtualTeamFlag() {
+    CtfFlagEntity virtualFlag = flagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
+        VIRTUAL_PROBLEM_ID, VIRTUAL_TEAM_ID).get();
+    CtfFlagEntity result = CtfChallengeAdminDto.getVirtualTeamFlag(
+        challengeRepository.getById(VIRTUAL_PROBLEM_ID));
+    assertThat(virtualFlag).isEqualTo(result);
+  }
+}

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfChallengeRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfChallengeRepositoryTest.java
@@ -44,6 +44,7 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
         .score(score)
         .ctfContestEntity(contest)
         .ctfFlagEntity(new ArrayList<>())
+        .maxSubmitCount(123L)
         .build();
     ctfChallengeRepository.save(challenge);
     CtfChallengeEntity findChallenge = ctfChallengeRepository.getById(challenge.getId());
@@ -87,6 +88,7 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
         .score(score)
         .ctfContestEntity(contest)
         .ctfFlagEntity(new ArrayList<>())
+        .maxSubmitCount(123L)
         .build();
     ctfChallengeRepository.save(challenge);
     CtfChallengeEntity findChallenge = ctfChallengeRepository.getById(challenge.getId());

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
@@ -20,7 +20,7 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
     return generateFlag(100L);
   }
 
-  private CtfFlagEntity generateFlag(long remainingSubmitCount) {
+  private CtfFlagEntity generateFlag(long remainedSubmitCount) {
     final long epochTime = System.nanoTime();
     String content = "content_" + epochTime;
     boolean isCorrect = true;
@@ -34,8 +34,8 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
         .ctfTeamEntity(ctfTeam)
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(isCorrect)
-        .lastSubmitTime(now)
-        .remainingSubmitCount(remainingSubmitCount)
+        .lastTryTime(now)
+        .remainedSubmitCount(remainedSubmitCount)
         .build();
   }
 
@@ -55,8 +55,8 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
     assertThat(findFlag.getCtfChallengeEntity().getId()).isEqualTo(
         flag.getCtfChallengeEntity().getId());
     assertThat(findFlag.getIsCorrect()).isEqualTo(flag.getIsCorrect());
-    assertThat(findFlag.getLastSubmitTime()).isEqualTo(flag.getLastSubmitTime());
-    assertThat(findFlag.getRemainingSubmitCount()).isEqualTo(flag.getRemainingSubmitCount());
+    assertThat(findFlag.getLastTryTime()).isEqualTo(flag.getLastTryTime());
+    assertThat(findFlag.getRemainedSubmitCount()).isEqualTo(flag.getRemainedSubmitCount());
   }
 
   @Test
@@ -64,7 +64,7 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
   void decreaseRemainingCount100Test() {
     CtfFlagEntity flag = generateFlag(100L);
     flag.decreaseSubmitCount();
-    assertThat(flag.getRemainingSubmitCount()).isEqualTo(99);
+    assertThat(flag.getRemainedSubmitCount()).isEqualTo(99);
   }
 
   @Test
@@ -72,7 +72,7 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
   void decreaseRemainingCount2Test() {
     CtfFlagEntity flag = generateFlag(2L);
     flag.decreaseSubmitCount();
-    assertThat(flag.getRemainingSubmitCount()).isEqualTo(1);
+    assertThat(flag.getRemainedSubmitCount()).isEqualTo(1);
   }
 
   @Test
@@ -80,7 +80,7 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
   void decreaseRemainingCount1Test() {
     CtfFlagEntity flag = generateFlag(1);
     flag.decreaseSubmitCount();
-    assertThat(flag.getRemainingSubmitCount()).isEqualTo(0);
+    assertThat(flag.getRemainedSubmitCount()).isEqualTo(0);
   }
 
   @Test

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
@@ -3,8 +3,9 @@ package keeper.project.homepage.ctf.repository;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
+import java.time.LocalDateTime;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -15,32 +16,79 @@ import org.junit.jupiter.api.Test;
 
 class CtfFlagRepositoryTest extends CtfTestHelper {
 
-  @Test
-  @DisplayName("CTF Flag 테스트")
-  void testContest() {
-    // given
+  private CtfFlagEntity generateFlag() {
+    return generateFlag(100L);
+  }
+
+  private CtfFlagEntity generateFlag(long remainingSubmitCount) {
     final long epochTime = System.nanoTime();
     String content = "content_" + epochTime;
     boolean isCorrect = true;
+    LocalDateTime now = LocalDateTime.now();
     MemberEntity member = memberRepository.getById(1L);
     CtfContestEntity contest = generateCtfContest(member);
     CtfTeamEntity ctfTeam = generateCtfTeam(contest, member, 0L);
     CtfChallengeEntity ctfChallenge = generateCtfChallenge(contest, STANDARD, MISC, 1000L);
-
-    // when
-    CtfFlagEntity flag = CtfFlagEntity.builder()
+    return CtfFlagEntity.builder()
         .content(content)
         .ctfTeamEntity(ctfTeam)
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(isCorrect)
+        .lastSubmitTime(now)
+        .remainingSubmitCount(remainingSubmitCount)
         .build();
+  }
+
+  @Test
+  @DisplayName("CTF Flag 정상 저장 테스트")
+  void flagSaveCorrectlyTest() {
+    // given
+    CtfFlagEntity flag = generateFlag();
+
+    // when
     ctfFlagRepository.save(flag);
     CtfFlagEntity findFlag = ctfFlagRepository.getById(flag.getId());
 
     // then
-    assertThat(findFlag.getContent()).isEqualTo(content);
-    assertThat(findFlag.getCtfTeamEntity().getId()).isEqualTo(ctfTeam.getId());
-    assertThat(findFlag.getCtfChallengeEntity().getId()).isEqualTo(ctfChallenge.getId());
-    assertThat(findFlag.getIsCorrect()).isEqualTo(isCorrect);
+    assertThat(findFlag.getContent()).isEqualTo(flag.getContent());
+    assertThat(findFlag.getCtfTeamEntity().getId()).isEqualTo(flag.getCtfTeamEntity().getId());
+    assertThat(findFlag.getCtfChallengeEntity().getId()).isEqualTo(
+        flag.getCtfChallengeEntity().getId());
+    assertThat(findFlag.getIsCorrect()).isEqualTo(flag.getIsCorrect());
+    assertThat(findFlag.getLastSubmitTime()).isEqualTo(flag.getLastSubmitTime());
+    assertThat(findFlag.getRemainingSubmitCount()).isEqualTo(flag.getRemainingSubmitCount());
   }
+
+  @Test
+  @DisplayName("남은 제출 횟수가 100일 때 정상적으로 줄어드는지 테스트")
+  void decreaseRemainingCount100Test() {
+    CtfFlagEntity flag = generateFlag(100L);
+    flag.decreaseSubmitCount();
+    assertThat(flag.getRemainingSubmitCount()).isEqualTo(99);
+  }
+
+  @Test
+  @DisplayName("남은 제출 횟수가 2일 때 정상적으로 줄어드는지 테스트")
+  void decreaseRemainingCount2Test() {
+    CtfFlagEntity flag = generateFlag(2L);
+    flag.decreaseSubmitCount();
+    assertThat(flag.getRemainingSubmitCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("남은 제출 횟수가 1일 때 정상적으로 줄어드는지 테스트")
+  void decreaseRemainingCount1Test() {
+    CtfFlagEntity flag = generateFlag(1);
+    flag.decreaseSubmitCount();
+    assertThat(flag.getRemainingSubmitCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("남은 제출 횟수가 0일 때 오류를 발생시키는지 테스트")
+  void decreaseRemainingCount0Test() {
+    CtfFlagEntity flag = generateFlag(0);
+    assertThatThrownBy(flag::decreaseSubmitCount)
+        .isInstanceOf(IllegalStateException.class);
+  }
+
 }

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
@@ -13,6 +13,8 @@ import keeper.project.homepage.ctf.entity.CtfTeamEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CtfFlagRepositoryTest extends CtfTestHelper {
 
@@ -59,34 +61,20 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
     assertThat(findFlag.getRemainedSubmitCount()).isEqualTo(flag.getRemainedSubmitCount());
   }
 
-  @Test
-  @DisplayName("남은 제출 횟수가 100일 때 정상적으로 줄어드는지 테스트")
-  void decreaseRemainingCount100Test() {
-    CtfFlagEntity flag = generateFlag(100L);
+  @ParameterizedTest
+  @ValueSource(ints = {100, 2, 1})
+  @DisplayName("남은 제출 횟수가 정상적으로 줄어드는지 테스트")
+  void decreaseRemainingCount(int count) {
+    CtfFlagEntity flag = generateFlag(count);
     flag.decreaseSubmitCount();
-    assertThat(flag.getRemainedSubmitCount()).isEqualTo(99);
+    assertThat(flag.getRemainedSubmitCount()).isEqualTo(count - 1);
   }
 
-  @Test
-  @DisplayName("남은 제출 횟수가 2일 때 정상적으로 줄어드는지 테스트")
-  void decreaseRemainingCount2Test() {
-    CtfFlagEntity flag = generateFlag(2L);
-    flag.decreaseSubmitCount();
-    assertThat(flag.getRemainedSubmitCount()).isEqualTo(1);
-  }
-
-  @Test
-  @DisplayName("남은 제출 횟수가 1일 때 정상적으로 줄어드는지 테스트")
-  void decreaseRemainingCount1Test() {
-    CtfFlagEntity flag = generateFlag(1);
-    flag.decreaseSubmitCount();
-    assertThat(flag.getRemainedSubmitCount()).isEqualTo(0);
-  }
-
-  @Test
-  @DisplayName("남은 제출 횟수가 0일 때 오류를 발생시키는지 테스트")
-  void decreaseRemainingCount0Test() {
-    CtfFlagEntity flag = generateFlag(0);
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, -1234})
+  @DisplayName("남은 제출 횟수가 0 이하일 때 오류를 발생시키는지 테스트")
+  void decreaseRemainingCount0Test(int count) {
+    CtfFlagEntity flag = generateFlag(count);
     assertThatThrownBy(flag::decreaseSubmitCount)
         .isInstanceOf(IllegalStateException.class);
   }

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfTestHelper.java
@@ -1,5 +1,7 @@
 package keeper.project.homepage.ctf.repository;
 
+import static java.time.LocalDateTime.now;
+
 import java.time.LocalDateTime;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
@@ -78,6 +80,7 @@ public class CtfTestHelper {
         .ctfTeamEntity(ctfTeam)
         .ctfChallengeEntity(ctfChallenge)
         .isCorrect(false)
+        .lastTryTime(now())
         .build();
     ctfFlagRepository.save(entity);
     return entity;

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfTestHelper.java
@@ -12,17 +12,8 @@ import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.ctf.entity.CtfSubmitLogEntity;
 import keeper.project.homepage.ctf.entity.CtfTeamEntity;
-import keeper.project.homepage.ctf.repository.CtfChallengeCategoryRepository;
-import keeper.project.homepage.ctf.repository.CtfChallengeRepository;
-import keeper.project.homepage.ctf.repository.CtfChallengeTypeRepository;
-import keeper.project.homepage.ctf.repository.CtfContestRepository;
-import keeper.project.homepage.ctf.repository.CtfFlagRepository;
-import keeper.project.homepage.ctf.repository.CtfSubmitLogRepository;
-import keeper.project.homepage.ctf.repository.CtfTeamRepository;
 import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.member.repository.MemberRepository;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -137,6 +128,7 @@ public class CtfTestHelper {
         .ctfChallengeCategoryEntity(ctfChallengeCategoryEntity)
         .score(score)
         .ctfContestEntity(ctfContestEntity)
+        .maxSubmitCount(123L)
         .build();
     ctfChallengeRepository.save(entity);
     return entity;

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -1,0 +1,101 @@
+package keeper.project.homepage.ctf.service;
+
+import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회장;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberRankName.일반회원;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberTypeName.정회원;
+import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.WEB;
+import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
+import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
+import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
+import keeper.project.homepage.ctf.entity.CtfContestEntity;
+import keeper.project.homepage.ctf.entity.CtfFlagEntity;
+import keeper.project.homepage.member.entity.MemberEntity;
+import keeper.project.homepage.util.service.CtfUtilService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class CtfAdminServiceTest extends CtfSpringTestHelper {
+
+  @Autowired
+  private CtfAdminService ctfAdminService;
+
+  private CtfContestEntity ctfContestEntity;
+
+  @BeforeEach
+  void setUp() {
+    MemberEntity contestCreator = generateMemberEntity(회장, 정회원, 일반회원);
+    setAuthentication(contestCreator, 회장);
+    ctfContestEntity = generateCtfContest(contestCreator);
+  }
+
+  private static void setAuthentication(MemberEntity contestCreator, MemberJobName memberJob) {
+    SecurityContext context = SecurityContextHolder.getContext();
+    context.setAuthentication(
+        new UsernamePasswordAuthenticationToken(contestCreator.getId(),
+            contestCreator.getPassword(),
+            List.of(new SimpleGrantedAuthority(memberJob.getJobName()))));
+  }
+
+  @Test
+  @DisplayName("문제 생성 테스트")
+  void createChallenge() {
+    CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
+        .isSolvable(true)
+        .flag("flag")
+        .submitCount(123L)
+        .type(getStandardType())
+        .dynamicInfo(null)
+        .content("content")
+        .title("title")
+        .score(1234L)
+        .category(getWebCategory())
+        .contestId(ctfContestEntity.getId())
+        .build();
+
+    CtfChallengeAdminDto result = ctfAdminService.createChallenge(challengeAdminDto);
+    CtfFlagEntity flag = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
+        result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
+
+    assertThat(result.getFlag()).isEqualTo("flag");
+    assertThat(result.getSubmitCount()).isEqualTo(123L);
+    assertThat(result.getType().getId()).isEqualTo(getStandardType().getId());
+    assertThat(result.getDynamicInfo().getMaxScore()).isNull();
+    assertThat(result.getDynamicInfo().getMinScore()).isNull();
+    assertThat(result.getContent()).isEqualTo("content");
+    assertThat(result.getTitle()).isEqualTo("title");
+    assertThat(result.getScore()).isEqualTo(1234L);
+    assertThat(result.getCategory().getId()).isEqualTo(getWebCategory().getId());
+    assertThat(result.getContestId()).isEqualTo(ctfContestEntity.getId());
+    assertThat(flag.getRemainingSubmitCount()).isEqualTo(123L);
+    assertThat(flag.getIsCorrect()).isEqualTo(false);
+
+
+  }
+
+  private static CtfChallengeCategoryDto getWebCategory() {
+    return CtfChallengeCategoryDto.builder()
+        .id(WEB.getId())
+        .name(WEB.getName())
+        .build();
+  }
+
+  private static CtfChallengeTypeDto getStandardType() {
+    return CtfChallengeTypeDto.builder()
+        .id(STANDARD.getId())
+        .name(STANDARD.getName())
+        .build();
+  }
+}

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -55,7 +55,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
         .isSolvable(true)
         .flag("flag")
-        .remainingSubmitCount(123L)
+        .remainedSubmitCount(123L)
         .type(getStandardType())
         .dynamicInfo(null)
         .content("content")
@@ -70,7 +70,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
         result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
 
     assertThat(result.getFlag()).isEqualTo("flag");
-    assertThat(result.getRemainingSubmitCount()).isEqualTo(123L);
+    assertThat(result.getRemainedSubmitCount()).isEqualTo(123L);
     assertThat(result.getType().getId()).isEqualTo(getStandardType().getId());
     assertThat(result.getDynamicInfo().getMaxScore()).isNull();
     assertThat(result.getDynamicInfo().getMinScore()).isNull();
@@ -79,7 +79,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     assertThat(result.getScore()).isEqualTo(1234L);
     assertThat(result.getCategory().getId()).isEqualTo(getWebCategory().getId());
     assertThat(result.getContestId()).isEqualTo(ctfContestEntity.getId());
-    assertThat(flag.getRemainingSubmitCount()).isEqualTo(123L);
+    assertThat(flag.getRemainedSubmitCount()).isEqualTo(123L);
     assertThat(flag.getIsCorrect()).isEqualTo(false);
 
 

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -55,7 +55,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
         .isSolvable(true)
         .flag("flag")
-        .submitCount(123L)
+        .remainingSubmitCount(123L)
         .type(getStandardType())
         .dynamicInfo(null)
         .content("content")
@@ -70,7 +70,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
         result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
 
     assertThat(result.getFlag()).isEqualTo("flag");
-    assertThat(result.getSubmitCount()).isEqualTo(123L);
+    assertThat(result.getRemainingSubmitCount()).isEqualTo(123L);
     assertThat(result.getType().getId()).isEqualTo(getStandardType().getId());
     assertThat(result.getDynamicInfo().getMaxScore()).isNull();
     assertThat(result.getDynamicInfo().getMinScore()).isNull();

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -55,7 +55,6 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
         .isSolvable(true)
         .flag("flag")
-        .remainedSubmitCount(123L)
         .type(getStandardType())
         .dynamicInfo(null)
         .content("content")
@@ -63,6 +62,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
         .score(1234L)
         .category(getWebCategory())
         .contestId(ctfContestEntity.getId())
+        .maxSubmitCount(123L)
         .build();
 
     CtfChallengeAdminDto result = ctfAdminService.createChallenge(challengeAdminDto);

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
@@ -165,8 +165,7 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
     LocalDateTime lastTryTime = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
             probId, teamEntity.getId())
         .orElseThrow()
-        .getLastTryTime()
-        .get();
+        .getLastTryTime();
     LocalDateTime after = now();
 
     // then

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
@@ -105,11 +105,11 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
 
   @Test
   @DisplayName("플래그 체크 - 남은 제출 횟수가 1 이상일 때 제출 팀의 제출 횟수가 차감되는지 확인")
-  void checkFlag_success_isDecreaseRemainingSubmitCount() {
+  void checkFlag_success_isDecreaseRemainedSubmitCount() {
     // given
-    long remainingSubmitCount = 123L;
+    long remainedSubmitCount = 123L;
     CtfFlagEntity flagEntity = generateCtfFlag(teamEntity, dynamicChallenge, false,
-        remainingSubmitCount);
+        remainedSubmitCount);
     Long probId = dynamicChallenge.getId();
     CtfFlagDto submitFlag = generateFlag(flagEntity.getContent());
 
@@ -117,12 +117,12 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
     ctfChallengeService.checkFlag(probId, submitFlag);
 
     // then
-    Long afterRemainingSubmitCount = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
+    Long afterRemainedSubmitCount = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
             probId, teamEntity.getId())
         .orElseThrow()
-        .getRemainingSubmitCount();
-    assertThat(afterRemainingSubmitCount).isNotNull();
-    assertThat(afterRemainingSubmitCount).isEqualTo(remainingSubmitCount - 1);
+        .getRemainedSubmitCount();
+    assertThat(afterRemainedSubmitCount).isNotNull();
+    assertThat(afterRemainedSubmitCount).isEqualTo(remainedSubmitCount - 1);
   }
 
   private void checkInitLastSolveTimeIsBeforeThanNow() {
@@ -132,11 +132,11 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
 
   @Test
   @DisplayName("플래그 체크 - 남은 제출 횟수가 0 일 때 제출 팀의 제출 횟수가 차감되는지 확인")
-  void checkFlag_fail_isDecreaseRemainingSubmitCount0() {
+  void checkFlag_fail_isDecreaseRemainedSubmitCount0() {
     // given
-    long remainingSubmitCount = 0L;
+    long remainedSubmitCount = 0L;
     CtfFlagEntity flagEntity = generateCtfFlag(teamEntity, dynamicChallenge, false,
-        remainingSubmitCount);
+        remainedSubmitCount);
     Long probId = dynamicChallenge.getId();
     CtfFlagDto submitFlag = generateFlag(flagEntity.getContent());
 

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
@@ -165,7 +165,8 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
     LocalDateTime lastTryTime = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
             probId, teamEntity.getId())
         .orElseThrow()
-        .getLastTryTime();
+        .getLastTryTime()
+        .get();
     LocalDateTime after = now();
 
     // then

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
@@ -168,7 +168,7 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         .category(CtfChallengeCategoryDto.builder()
             .id(MISC.getId())
             .build())
-        .remainedSubmitCount(100L)
+        .maxSubmitCount(100L)
         .build();
     return ctfAdminService.createChallenge(createChallenge);
   }

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
@@ -168,7 +168,7 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         .category(CtfChallengeCategoryDto.builder()
             .id(MISC.getId())
             .build())
-        .submitCount(100L)
+        .remainingSubmitCount(100L)
         .build();
     return ctfAdminService.createChallenge(createChallenge);
   }

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
@@ -168,7 +168,7 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         .category(CtfChallengeCategoryDto.builder()
             .id(MISC.getId())
             .build())
-        .remainingSubmitCount(100L)
+        .remainedSubmitCount(100L)
         .build();
     return ctfAdminService.createChallenge(createChallenge);
   }

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
@@ -17,9 +17,6 @@ import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.ctf.entity.CtfSubmitLogEntity;
-import keeper.project.homepage.ctf.service.CtfAdminService;
-import keeper.project.homepage.ctf.service.CtfChallengeService;
-import keeper.project.homepage.ctf.service.CtfTeamService;
 import keeper.project.homepage.member.entity.MemberEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -171,6 +168,7 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         .category(CtfChallengeCategoryDto.builder()
             .id(MISC.getId())
             .build())
+        .submitCount(100L)
         .build();
     return ctfAdminService.createChallenge(createChallenge);
   }

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
@@ -184,7 +184,7 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
             CtfChallengeCategoryDto.builder().id(SYSTEM.getId()).build())
         .title(testTitle)
         .score(testScore)
-        .remainingSubmitCount(123L)
+        .remainedSubmitCount(123L)
         .build();
     ctfAdminService.createChallenge(createChallengeInfo);
 

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
@@ -5,17 +5,13 @@ import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChall
 
 import java.time.LocalDateTime;
 import java.util.List;
-import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
-import keeper.project.homepage.ctf.service.CtfAdminService;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
-import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
-import keeper.project.homepage.ctf.entity.CtfContestEntity;
-import keeper.project.homepage.ctf.service.CtfTeamService;
-import keeper.project.homepage.member.entity.MemberEntity;
+import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
+import keeper.project.homepage.ctf.entity.CtfContestEntity;
+import keeper.project.homepage.member.entity.MemberEntity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -188,6 +184,7 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
             CtfChallengeCategoryDto.builder().id(SYSTEM.getId()).build())
         .title(testTitle)
         .score(testScore)
+        .submitCount(123L)
         .build();
     ctfAdminService.createChallenge(createChallengeInfo);
 

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
@@ -184,7 +184,7 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
             CtfChallengeCategoryDto.builder().id(SYSTEM.getId()).build())
         .title(testTitle)
         .score(testScore)
-        .submitCount(123L)
+        .remainingSubmitCount(123L)
         .build();
     ctfAdminService.createChallenge(createChallengeInfo);
 

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
@@ -184,7 +184,7 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
             CtfChallengeCategoryDto.builder().id(SYSTEM.getId()).build())
         .title(testTitle)
         .score(testScore)
-        .remainedSubmitCount(123L)
+        .maxSubmitCount(123L)
         .build();
     ctfAdminService.createChallenge(createChallengeInfo);
 


### PR DESCRIPTION
## 연관 issue

close : #462

- #462

## 프론트 전달사항

총 4개 API의 response에 추가사항이 있습니다.

### 1. CTF 문제 API
  - 문제 정보나 문제 세부 정보 응답에 아래 3가지 옵션이 추가되었습니다.

Path | Type | Description
-- | -- | --
data.maxSubmitCount | Number | 최대 제출 횟수
data.remainedSubmitCount | Number | 남은 제출 횟수
data.lastTryTime | String | 각 팀별 마지막 제출 시간입니다. 만약 5초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다.

### 2. CTF 팀 API
  - 팀 세부 정보를 열람할 때 아래와 같은 정보들이 추가되어 나갑니다.

Path | Type | Description
-- | -- | --
data.solvedChallengeList | Array | team이 푼 문제들 정보 (푼 문제이므로 남은 제출 횟수가 0으로 표기되어 나갑니다.)
data.lastSolvedTime | String | 마지막으로 푼 문제 시간

### 3. CTF 관리자 API
   - 문제 생성시 아래와 같은 정보를 추가로 기입해야 합니다.

Parameter | Type | Neccsesary | Description
-- | -- | -- | --
maxSubmitCount | Number | true | 각 팀당 가능한 최대 제출 횟수

  - 관리자 API 역시 문제 생성 시 아래와 같은 정보들이 주어지는데, 프론트에서 무시하셔도 됩니다.

Path | Type | Description
-- | -- | --
data.remainedSubmitCount | Number | 남은 제출 횟수
data.lastTryTime | String | 각 팀별 마지막 제출 시간입니다. 만약 5초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다.

