### PR TITLE
Feature/#465 상벌점 문제 해결

### DIFF
--- a/src/main/java/keeper/project/homepage/clerk/repository/MeritLogRepository.java
+++ b/src/main/java/keeper/project/homepage/clerk/repository/MeritLogRepository.java
@@ -16,6 +16,8 @@ public interface MeritLogRepository extends JpaRepository<MeritLogEntity, Long> 
   List<MeritLogEntity> findAllByYear(@Param("year") Integer year);
 
   Optional<MeritLogEntity> findFirstByOrderByDate();
+  Optional<MeritLogEntity> findFirstByOrderByDateDesc();
+
   // 결석일 때만 사용해야 함
   List<MeritLogEntity> findByAwarderAndMeritTypeAndDate(MemberEntity awarder, MeritTypeEntity meritType,
       LocalDate date);

--- a/src/main/java/keeper/project/homepage/clerk/repository/MeritLogRepository.java
+++ b/src/main/java/keeper/project/homepage/clerk/repository/MeritLogRepository.java
@@ -22,4 +22,6 @@ public interface MeritLogRepository extends JpaRepository<MeritLogEntity, Long> 
 
   boolean existsByAwarderAndMeritTypeAndDate(MemberEntity awarder, MeritTypeEntity meritType,
       LocalDate date);
+
+  boolean existsByMeritType(MeritTypeEntity meritType);
 }

--- a/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
+++ b/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
@@ -2,6 +2,7 @@ package keeper.project.homepage.clerk.service;
 
 import static keeper.project.homepage.clerk.entity.SeminarAttendanceStatusEntity.SeminarAttendanceStatus.ABSENCE;
 
+import io.netty.channel.local.LocalAddress;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,6 +24,7 @@ import keeper.project.homepage.clerk.exception.CustomMeritTypeNotFoundException;
 import keeper.project.homepage.clerk.repository.MeritLogRepository;
 import keeper.project.homepage.clerk.repository.MeritTypeRepository;
 import keeper.project.homepage.member.entity.MemberEntity;
+import keeper.project.homepage.member.repository.MemberRepository;
 import keeper.project.homepage.member.service.MemberUtilService;
 import keeper.project.homepage.util.service.auth.AuthService;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AdminMeritService {
 
+  private final MemberRepository memberRepository;
   private final MeritLogRepository meritLogRepository;
 
   private final MeritTypeRepository meritTypeRepository;
@@ -46,9 +49,11 @@ public class AdminMeritService {
 
   public List<Integer> getYears() {
     try {
-      MeritLogEntity meritLog = meritLogRepository.findFirstByOrderByDate()
-          .orElseThrow(CustomMeritLogNotFoundException::new);
-      return IntStream.range(meritLog.getDate().getYear(), LocalDate.now().getYear() + 1)
+      int recentYear = meritLogRepository.findFirstByOrderByDateDesc()
+          .orElseThrow(CustomMeritLogNotFoundException::new).getDate().getYear();
+      int oldestYear = meritLogRepository.findFirstByOrderByDate()
+          .orElseThrow(CustomMeritLogNotFoundException::new).getDate().getYear();
+      return IntStream.range(oldestYear, recentYear+ 1)
           .boxed()
           .toList();
     } catch (Exception e) {

--- a/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
+++ b/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
@@ -70,7 +70,7 @@ public class AdminMeritService {
   }
 
   public List<MemberTotalMeritLogsResponseDto> getMemberTotalMeritLogs() {
-    List<MeritLogEntity> meritLogs = meritLogRepository.findAll();
+    List<MeritLogEntity> meritLogs = meritLogRepository.findAllByYear(LocalDate.now().getYear());
     Map<MemberEntity, List<MeritLogEntity>> meritLogMap = meritLogs.stream()
         .collect(Collectors.groupingBy(MeritLogEntity::getAwarder));
     return meritLogMap.entrySet()

--- a/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
+++ b/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
@@ -214,12 +214,12 @@ public class AdminMeritService {
   public Long deleteMeritType(Long typeId) {
     MeritTypeEntity meritTypeEntity = meritTypeRepository.findById(typeId)
         .orElseThrow(CustomMeritTypeNotFoundException::new);
-    checkUsedMeritType(meritTypeEntity);
+    validateUsedMeritType(meritTypeEntity);
     meritTypeRepository.delete(meritTypeEntity);
     return meritTypeEntity.getId();
   }
 
-  private void checkUsedMeritType(MeritTypeEntity meritTypeEntity) {
+  private void validateUsedMeritType(MeritTypeEntity meritTypeEntity) {
     if (meritLogRepository.existsByMeritType(meritTypeEntity)) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
+++ b/src/main/java/keeper/project/homepage/clerk/service/AdminMeritService.java
@@ -101,6 +101,7 @@ public class AdminMeritService {
       throw new CustomDuplicateAbsenceLogException();
     }
   }
+
   private static MeritLogEntity getMeritLog(LocalDate date,
       MeritTypeEntity meritType, MemberEntity awarder, MemberEntity giver) {
     return MeritLogEntity.builder()
@@ -208,7 +209,14 @@ public class AdminMeritService {
   public Long deleteMeritType(Long typeId) {
     MeritTypeEntity meritTypeEntity = meritTypeRepository.findById(typeId)
         .orElseThrow(CustomMeritTypeNotFoundException::new);
+    checkUsedMeritType(meritTypeEntity);
     meritTypeRepository.delete(meritTypeEntity);
     return meritTypeEntity.getId();
+  }
+
+  private void checkUsedMeritType(MeritTypeEntity meritTypeEntity) {
+    if (meritLogRepository.existsByMeritType(meritTypeEntity)) {
+      throw new IllegalArgumentException();
+    }
   }
 }

--- a/src/main/java/keeper/project/homepage/member/service/AdminMemberService.java
+++ b/src/main/java/keeper/project/homepage/member/service/AdminMemberService.java
@@ -18,7 +18,9 @@ import keeper.project.homepage.member.exception.CustomMemberEmptyFieldException;
 import keeper.project.homepage.member.repository.MemberHasMemberJobRepository;
 import keeper.project.homepage.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -170,4 +172,13 @@ public class AdminMemberService {
     return result;
   }
 
+  // 회원의 상벌점은 매년 학기 시작일인 3, 9월 1일에 초기화 됩니다.
+  @Scheduled(cron = "0 0 0 1 3,9 ?")
+  @Transactional
+  public void initMembersMerit() {
+    memberRepository.findAll().forEach(member -> {
+      member.changeDemerit(0);
+      member.changeMerit(0);
+    });
+  }
 }

--- a/src/main/java/keeper/project/homepage/member/service/AdminMemberService.java
+++ b/src/main/java/keeper/project/homepage/member/service/AdminMemberService.java
@@ -176,9 +176,12 @@ public class AdminMemberService {
   @Scheduled(cron = "0 0 0 1 3,9 ?")
   @Transactional
   public void initMembersMerit() {
-    memberRepository.findAll().forEach(member -> {
-      member.changeDemerit(0);
-      member.changeMerit(0);
-    });
+    memberRepository.findAll()
+        .forEach(AdminMemberService::initMemberMerit);
+  }
+
+  private static void initMemberMerit(MemberEntity member) {
+    member.changeDemerit(0);
+    member.changeMerit(0);
   }
 }

--- a/src/test/java/keeper/project/homepage/clerk/controller/AdminMeritControllerTest.java
+++ b/src/test/java/keeper/project/homepage/clerk/controller/AdminMeritControllerTest.java
@@ -222,6 +222,7 @@ public class AdminMeritControllerTest extends ClerkControllerTestHelper {
     int latestYear = now.getYear();
     int oldestYear = oldest.getYear();
 
+    generateMeritLog(awarder, giver, publicAnnouncement, now);
     generateMeritLog(awarder, giver, publicAnnouncement, oldest);
 
     mockMvc.perform(get("/v1/admin/clerk/merits/years")

--- a/src/test/java/keeper/project/homepage/clerk/service/AdminClerkServiceTestHelper.java
+++ b/src/test/java/keeper/project/homepage/clerk/service/AdminClerkServiceTestHelper.java
@@ -2,7 +2,20 @@ package keeper.project.homepage.clerk.service;
 
 import static keeper.project.homepage.member.entity.MemberTypeEntity.memberType.DORMANT_MEMBER;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import javax.persistence.EntityManager;
+import keeper.project.homepage.clerk.entity.MeritLogEntity;
+import keeper.project.homepage.clerk.entity.MeritTypeEntity;
+import keeper.project.homepage.clerk.entity.SeminarAttendanceEntity;
+import keeper.project.homepage.clerk.entity.SeminarAttendanceStatusEntity;
+import keeper.project.homepage.clerk.entity.SeminarEntity;
+import keeper.project.homepage.clerk.repository.MeritLogRepository;
+import keeper.project.homepage.clerk.repository.MeritTypeRepository;
+import keeper.project.homepage.clerk.repository.SeminarAttendanceRepository;
+import keeper.project.homepage.clerk.repository.SeminarAttendanceStatusRepository;
+import keeper.project.homepage.clerk.repository.SeminarRepository;
 import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.member.entity.MemberTypeEntity;
 import keeper.project.homepage.member.repository.MemberRepository;
@@ -21,14 +34,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminClerkServiceTestHelper {
 
   @Autowired
-  AdminMeritService adminMeritService;
+  EntityManager em;
+  @Autowired
+  AdminSeminarService adminSeminarService;
 
+  @Autowired
+  SeminarAttendanceStatusRepository seminarAttendanceStatusRepository;
+  @Autowired
+  MemberRepository memberRepository;
+  @Autowired
+  SeminarRepository seminarRepository;
   @Autowired
   MemberTypeRepository memberTypeRepository;
 
   @Autowired
-  MemberRepository memberRepository;
-  private MemberEntity clerk;
+  MeritTypeRepository meritTypeRepository;
+  @Autowired
+  SeminarAttendanceRepository seminarAttendanceRepository;
+  @Autowired
+  AdminMeritService adminMeritService;
+
+  @Autowired
+  MeritLogRepository meritLogRepository;
+
+  MemberEntity clerk;
 
   @BeforeEach
   void beforeEach() {
@@ -53,5 +82,27 @@ public class AdminClerkServiceTestHelper {
             .generation(generation)
             .memberType(type)
             .build());
+  }
+
+  MeritLogEntity generateMeritLog(MemberEntity member, MeritTypeEntity meritType) {
+    return meritLogRepository.save(
+        MeritLogEntity.builder()
+            .meritType(meritType)
+            .awarder(member)
+            .giver(clerk)
+            .date(LocalDate.now())
+            .build());
+  }
+
+  SeminarAttendanceEntity generateSeminarAttendance(MemberEntity member, SeminarEntity seminar,
+      SeminarAttendanceStatusEntity status, LocalDateTime seminarInitTime) {
+    return seminarAttendanceRepository.save(
+        SeminarAttendanceEntity.builder()
+            .memberEntity(member)
+            .seminarEntity(seminar)
+            .seminarAttendanceStatusEntity(status)
+            .seminarAttendTime(seminarInitTime)
+            .build()
+    );
   }
 }

--- a/src/test/java/keeper/project/homepage/clerk/service/AdminClerkServiceTestHelper.java
+++ b/src/test/java/keeper/project/homepage/clerk/service/AdminClerkServiceTestHelper.java
@@ -1,0 +1,57 @@
+package keeper.project.homepage.clerk.service;
+
+import static keeper.project.homepage.member.entity.MemberTypeEntity.memberType.DORMANT_MEMBER;
+
+import java.util.List;
+import keeper.project.homepage.member.entity.MemberEntity;
+import keeper.project.homepage.member.entity.MemberTypeEntity;
+import keeper.project.homepage.member.repository.MemberRepository;
+import keeper.project.homepage.member.repository.MemberTypeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class AdminClerkServiceTestHelper {
+
+  @Autowired
+  AdminMeritService adminMeritService;
+
+  @Autowired
+  MemberTypeRepository memberTypeRepository;
+
+  @Autowired
+  MemberRepository memberRepository;
+  private MemberEntity clerk;
+
+  @BeforeEach
+  void beforeEach() {
+    MemberTypeEntity dormantMember = memberTypeRepository.getById(DORMANT_MEMBER.getId());
+    clerk = generateMember("서기", 12F, dormantMember);
+    SecurityContext context = SecurityContextHolder.getContext();
+    context.setAuthentication(
+        new UsernamePasswordAuthenticationToken(clerk.getId(), clerk.getPassword(),
+            List.of(new SimpleGrantedAuthority("ROLE_서기"))));
+  }
+
+  public MemberEntity generateMember(String name, Float generation, MemberTypeEntity type) {
+    final long epochTime = System.nanoTime();
+    return memberRepository.save(
+        MemberEntity.builder()
+            .loginId("abcd1234" + epochTime)
+            .emailAddress("test1234@keeper.co.kr" + epochTime)
+            .password("1234")
+            .studentId("1234" + epochTime)
+            .nickName("nick" + epochTime)
+            .realName(name)
+            .generation(generation)
+            .memberType(type)
+            .build());
+  }
+}

--- a/src/test/java/keeper/project/homepage/clerk/service/AdminMeritServiceTest.java
+++ b/src/test/java/keeper/project/homepage/clerk/service/AdminMeritServiceTest.java
@@ -1,0 +1,37 @@
+package keeper.project.homepage.clerk.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import keeper.project.homepage.clerk.dto.request.MeritAddRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class AdminMeritServiceTest extends AdminClerkServiceTestHelper {
+
+  @Test
+  @DisplayName("이미 상벌점 내역에 있는 타입이면 삭제 불가")
+  void deleteMeritTypeIfExistLog() {
+    // given
+    MeritAddRequestDto request = getVirtualMeritAddRequestDto(LocalDate.now());
+
+    // when
+    adminMeritService.addMeritWithLog(request);
+
+    // then
+    assertThrows(IllegalArgumentException.class, () -> adminMeritService.deleteMeritType(1L));
+  }
+
+  private static MeritAddRequestDto getVirtualMeritAddRequestDto(LocalDate date) {
+    return MeritAddRequestDto.builder()
+        .date(date)
+        .meritTypeId(1L)
+        .memberId(1L)
+        .build();
+  }
+}

--- a/src/test/java/keeper/project/homepage/clerk/service/AdminMeritServiceTest.java
+++ b/src/test/java/keeper/project/homepage/clerk/service/AdminMeritServiceTest.java
@@ -4,9 +4,15 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import keeper.project.homepage.clerk.dto.request.MeritAddRequestDto;
+import keeper.project.homepage.clerk.entity.MeritLogEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +31,24 @@ class AdminMeritServiceTest extends AdminClerkServiceTestHelper {
 
     // then
     assertThrows(IllegalArgumentException.class, () -> adminMeritService.deleteMeritType(1L));
+  }
+
+  @Test
+  @DisplayName("서로 다른 해에 상벌점 내역 추가시 연도 리스트에 추가되어야 한다")
+  void addMeritLogTest() {
+    // given
+    LocalDate toDay = LocalDate.now();
+    List<LocalDate> dates = List.of(toDay, toDay.minusYears(2L), toDay.plusYears(1L));
+    List<MeritAddRequestDto> requests = dates.stream()
+        .map(AdminMeritServiceTest::getVirtualMeritAddRequestDto).toList();
+
+    // when
+    requests.forEach(request -> adminMeritService.addMeritWithLog(request));
+    List<Integer> years = adminMeritService.getYears();
+
+    // then
+    assertThat(years).containsAll(
+        dates.stream().map(LocalDate::getYear).collect(Collectors.toList()));
   }
 
   private static MeritAddRequestDto getVirtualMeritAddRequestDto(LocalDate date) {

--- a/src/test/java/keeper/project/homepage/clerk/service/AdminSeminarServiceTest.java
+++ b/src/test/java/keeper/project/homepage/clerk/service/AdminSeminarServiceTest.java
@@ -49,38 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
-public class AdminSeminarServiceTest {
-
-  @Autowired
-  EntityManager em;
-  @Autowired
-  AdminSeminarService adminSeminarService;
-  @Autowired
-  SeminarAttendanceRepository seminarAttendanceRepository;
-  @Autowired
-  SeminarAttendanceStatusRepository seminarAttendanceStatusRepository;
-  @Autowired
-  MemberRepository memberRepository;
-  @Autowired
-  SeminarRepository seminarRepository;
-  @Autowired
-  MemberTypeRepository memberTypeRepository;
-  @Autowired
-  MeritLogRepository meritLogRepository;
-  @Autowired
-  MeritTypeRepository meritTypeRepository;
-
-  private MemberEntity clerk;
-
-  @BeforeEach
-  void beforeEach() {
-    MemberTypeEntity dormantMember = memberTypeRepository.getById(DORMANT_MEMBER.getId());
-    clerk = generateMember("서기", 12F, dormantMember);
-    SecurityContext context = SecurityContextHolder.getContext();
-    context.setAuthentication(
-        new UsernamePasswordAuthenticationToken(clerk.getId(), clerk.getPassword(),
-            List.of(new SimpleGrantedAuthority("ROLE_서기"))));
-  }
+public class AdminSeminarServiceTest extends AdminClerkServiceTestHelper {
 
   @Test
   @DisplayName("[SUCCESS] 세미나 생성 테스트")
@@ -449,42 +418,6 @@ public class AdminSeminarServiceTest {
     assertThat(meritLogRepository.existsById(afterMeritLog.getId())).isTrue();
   }
 
-  MemberEntity generateMember(String name, Float generation, MemberTypeEntity type) {
-    final long epochTime = System.nanoTime();
-    return memberRepository.save(
-        MemberEntity.builder()
-            .loginId("abcd1234" + epochTime)
-            .emailAddress("test1234@keeper.co.kr" + epochTime)
-            .password("1234")
-            .studentId("1234" + epochTime)
-            .nickName("nick" + epochTime)
-            .realName(name)
-            .generation(generation)
-            .memberType(type)
-            .build());
-  }
-
-  private MeritLogEntity generateMeritLog(MemberEntity member, MeritTypeEntity meritType) {
-    return meritLogRepository.save(
-        MeritLogEntity.builder()
-            .meritType(meritType)
-            .awarder(member)
-            .giver(clerk)
-            .date(LocalDate.now())
-            .build());
-  }
-
-  SeminarAttendanceEntity generateSeminarAttendance(MemberEntity member, SeminarEntity seminar,
-      SeminarAttendanceStatusEntity status, LocalDateTime seminarInitTime) {
-    return seminarAttendanceRepository.save(
-        SeminarAttendanceEntity.builder()
-            .memberEntity(member)
-            .seminarEntity(seminar)
-            .seminarAttendanceStatusEntity(status)
-            .seminarAttendTime(seminarInitTime)
-            .build()
-    );
-  }
 
   SeminarAttendanceStatusEntity getSeminarAttendanceStatus(SeminarAttendanceStatus status) {
     return seminarAttendanceStatusRepository.getById(status.getId());

--- a/src/test/java/keeper/project/homepage/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/keeper/project/homepage/member/service/AdminMemberServiceTest.java
@@ -2,8 +2,9 @@ package keeper.project.homepage.member.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
+import java.util.Set;
 import javax.persistence.EntityManager;
-import keeper.project.homepage.ApiControllerTestHelper;
 import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.member.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
@@ -11,11 +12,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.config.CronTask;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
 class AdminMemberServiceTest {
+
+  @Autowired
+  ScheduledTaskHolder scheduledTaskHolder;
 
   @Autowired
   EntityManager em;
@@ -40,6 +47,22 @@ class AdminMemberServiceTest {
     // then
     Assertions.assertThat(virtualMember.getMerit()).isZero();
     Assertions.assertThat(virtualMember.getMerit()).isZero();
+  }
+
+  @Test
+  @DisplayName("스케줄이 예약되어 있는지 확인")
+  void checkScheduleReserved() {
+    // given
+    Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();
+
+    // when
+    List<String> scheduledTaskPaths = scheduledTasks.stream()
+        .filter(scheduledTask -> scheduledTask.getTask() instanceof CronTask)
+        .map(scheduledTask -> (scheduledTask.getTask()).toString()).toList();
+
+    // then
+    Assertions.assertThat(scheduledTaskPaths)
+        .contains("keeper.project.homepage.member.service.AdminMemberService.initMembersMerit");
   }
 
 }

--- a/src/test/java/keeper/project/homepage/member/service/AdminMemberServiceTest.java
+++ b/src/test/java/keeper/project/homepage/member/service/AdminMemberServiceTest.java
@@ -1,0 +1,45 @@
+package keeper.project.homepage.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+import keeper.project.homepage.ApiControllerTestHelper;
+import keeper.project.homepage.member.entity.MemberEntity;
+import keeper.project.homepage.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class AdminMemberServiceTest {
+
+  @Autowired
+  EntityManager em;
+
+  @Autowired
+  AdminMemberService adminMemberService;
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("회원 상벌점 초기화 테스트")
+  void initMembersMerit() {
+    // given
+    MemberEntity virtualMember = memberRepository.getById(1L);
+    virtualMember.changeMerit(3);
+    virtualMember.changeDemerit(2);
+
+    // when
+    adminMemberService.initMembersMerit();
+
+    // then
+    Assertions.assertThat(virtualMember.getMerit()).isZero();
+    Assertions.assertThat(virtualMember.getMerit()).isZero();
+  }
+
+}


### PR DESCRIPTION
## 연관 issue

close : #465 

1. 기존에 올해 이후의 연도는 연도 리스트에 추가되지 않아 상벌점 내역을 불러오지 못했습니다. 
   그래서 가장 오래된 내역과 가장 최근 또는 미래의 내역 사이 연도값을 리스트로 반환하도록 수정했습니다.
3. 상벌점 내역에 존재하는 상벌점 타입은 삭제되지 않도록 수정했습니다.
4. @Scheduled를 사용하여 매학기 시작하는 날 회원의 상벌점이 초기화되도록 구현하였습니다.

## 프론트 전달사항
.