### PR TITLE
Feature/#467 ctf fe 추가요청사항

### DIFF
--- a/src/main/java/keeper/project/homepage/ctf/controller/CtfAdminController.java
+++ b/src/main/java/keeper/project/homepage/ctf/controller/CtfAdminController.java
@@ -2,6 +2,7 @@ package keeper.project.homepage.ctf.controller;
 
 import java.nio.file.AccessDeniedException;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfContestAdminDto;
 import keeper.project.homepage.ctf.dto.CtfProbMakerDto;
@@ -90,7 +91,7 @@ public class CtfAdminController {
   @Secured({"ROLE_회장", "ROLE_출제자"})
   @PostMapping(value = "/prob")
   public SingleResult<CtfChallengeAdminDto> createProblem(
-      @RequestBody CtfChallengeAdminDto challengeAdminDto
+      @Valid @RequestBody CtfChallengeAdminDto challengeAdminDto
   ) {
     return responseService.getSuccessSingleResult(
         ctfAdminService.createChallenge(challengeAdminDto));

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -39,7 +39,6 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
 
   public CtfChallengeEntity toEntity(CtfContestEntity contest, CtfChallengeTypeEntity type,
       CtfChallengeCategoryEntity category, FileEntity fileEntity, MemberEntity creator) {
-    System.out.println("maxSubmitCount = " + maxSubmitCount);
     return CtfChallengeEntity.builder()
         .name(title)
         .description(content)

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -56,7 +56,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .build();
   }
 
-  public static CtfChallengeAdminDto toDto(CtfChallengeEntity challenge) {
+  public static CtfChallengeAdminDto toDto(CtfChallengeEntity challenge, Long solvedTeamCount) {
     CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
         challenge.getCtfChallengeCategoryEntity());
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
@@ -77,6 +77,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .isSolvable(challenge.getIsSolvable())
         .registerTime(challenge.getRegisterTime())
         .creatorName(challenge.getCreator().getNickName())
+        .solvedTeamCount(solvedTeamCount)
         .score(challenge.getScore())
         .file(file)
         .dynamicInfo(dynamicInfo)

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -1,7 +1,5 @@
 package keeper.project.homepage.ctf.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -27,7 +25,6 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
-@JsonInclude(Include.NON_NULL)
 public class CtfChallengeAdminDto extends CtfChallengeDto {
 
   private Boolean isSolvable;
@@ -42,6 +39,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
 
   public CtfChallengeEntity toEntity(CtfContestEntity contest, CtfChallengeTypeEntity type,
       CtfChallengeCategoryEntity category, FileEntity fileEntity, MemberEntity creator) {
+    System.out.println("maxSubmitCount = " + maxSubmitCount);
     return CtfChallengeEntity.builder()
         .name(title)
         .description(content)
@@ -84,6 +82,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .dynamicInfo(dynamicInfo)
         .remainedSubmitCount(getVirtualTeamFlag(challenge).getRemainedSubmitCount())
         .lastTryTime(getVirtualTeamFlag(challenge).getLastTryTime())
+        .solvedTime(getVirtualTeamFlag(challenge).getSolvedTime())
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -18,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
-@JsonInclude(Include.NON_NULL)
 public class CtfChallengeDto extends CtfCommonChallengeDto {
 
   protected String content;
@@ -50,6 +49,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .file(file)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
         .lastTryTime(ctfFlagEntity.getLastTryTime())
+        .solvedTime(ctfFlagEntity.getSolvedTime())
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -40,6 +40,8 @@ public class CtfCommonChallengeDto {
   @JsonProperty(access = Access.READ_ONLY)
   protected LocalDateTime lastTryTime;
   @JsonProperty(access = Access.READ_ONLY)
+  protected LocalDateTime solvedTime;
+  @JsonProperty(access = Access.READ_ONLY)
   protected Long challengeId;
   @JsonProperty(access = Access.READ_ONLY)
   protected Boolean isSolved;
@@ -58,6 +60,7 @@ public class CtfCommonChallengeDto {
         .isSolved(isSolved)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())
         .lastTryTime(ctfFlagEntity.getLastTryTime())
+        .solvedTime(ctfFlagEntity.getSolvedTime())
         .maxSubmitCount(challenge.getMaxSubmitCount())
         .build();
   }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -1,7 +1,5 @@
 package keeper.project.homepage.ctf.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import java.time.LocalDateTime;
@@ -20,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
-@JsonInclude(Include.NON_NULL)
 public class CtfCommonChallengeDto {
 
   public static final long MAX_SUBMIT_COUNT = 50;

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -2,6 +2,8 @@ package keeper.project.homepage.ctf.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.time.LocalDateTime;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -30,6 +32,7 @@ public class CtfCommonChallengeDto {
   protected Long contestId;
   @Max(MAX_SUBMIT_COUNT)
   @Min(MIN_SUBMIT_COUNT)
+  @JsonSetter(nulls = Nulls.SKIP)
   protected Long maxSubmitCount = DEFAULT_SUBMIT_COUNT;
 
   @JsonProperty(access = Access.READ_ONLY)

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import java.time.LocalDateTime;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import lombok.AllArgsConstructor;
@@ -21,11 +23,17 @@ import lombok.experimental.SuperBuilder;
 @JsonInclude(Include.NON_NULL)
 public class CtfCommonChallengeDto {
 
+  public static final long MAX_SUBMIT_COUNT = 50;
+  public static final long MIN_SUBMIT_COUNT = 1;
+  public static final long DEFAULT_SUBMIT_COUNT = 15;
+
   protected String title;
   protected Long score;
   protected CtfChallengeCategoryDto category;
   protected Long contestId;
-  protected Long maxSubmitCount;
+  @Max(MAX_SUBMIT_COUNT)
+  @Min(MIN_SUBMIT_COUNT)
+  protected Long maxSubmitCount = DEFAULT_SUBMIT_COUNT;
 
   @JsonProperty(access = Access.READ_ONLY)
   protected Long remainedSubmitCount;

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfFlagEntity.java
@@ -57,8 +57,8 @@ public class CtfFlagEntity {
   @Column(name = "remained_submit_count")
   Long remainedSubmitCount;
 
-  public void updateLastTryTime() {
-    lastTryTime = LocalDateTime.now();
+  public void updateLastTryTime(LocalDateTime now) {
+    lastTryTime = now;
   }
 
   public void decreaseSubmitCount() {

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -117,7 +117,7 @@ public class CtfAdminService {
     }
     setFlagAllTeam(challengeAdminDto.getFlag(), newChallenge,
         challengeAdminDto.getMaxSubmitCount());
-    return CtfChallengeAdminDto.toDto(newChallenge);
+    return CtfChallengeAdminDto.toDto(newChallenge, 0L);
   }
 
   @Transactional
@@ -133,7 +133,7 @@ public class CtfAdminService {
     ctfUtilService.checkVirtualProblem(problemId);
     CtfChallengeEntity challenge = getChallengeById(problemId);
     challenge.setIsSolvable(true);
-    return CtfChallengeAdminDto.toDto(challenge);
+    return CtfChallengeAdminDto.toDto(challenge, getSolvedTeamCount(problemId));
   }
 
   @Transactional
@@ -141,7 +141,7 @@ public class CtfAdminService {
     ctfUtilService.checkVirtualProblem(problemId);
     CtfChallengeEntity challenge = getChallengeById(problemId);
     challenge.setIsSolvable(false);
-    return CtfChallengeAdminDto.toDto(challenge);
+    return CtfChallengeAdminDto.toDto(challenge, getSolvedTeamCount(problemId));
   }
 
   @Transactional
@@ -158,7 +158,7 @@ public class CtfAdminService {
       fileService.deleteFile(challenge.getFileEntity());
     }
     challengeRepository.delete(challenge);
-    return CtfChallengeAdminDto.toDto(challenge);
+    return CtfChallengeAdminDto.toDto(challenge, 0L);
   }
 
   private boolean hasFileEntity(CtfChallengeEntity challenge) {
@@ -174,7 +174,12 @@ public class CtfAdminService {
     CtfContestEntity contest = getContest(ctfId);
     return challengeRepository
         .findAllByIdIsNotAndCtfContestEntity(VIRTUAL_PROBLEM_ID, contest, pageable)
-        .map(CtfChallengeAdminDto::toDto);
+        .map((challenge) -> CtfChallengeAdminDto.toDto(challenge,
+            getSolvedTeamCount(challenge.getId())));
+  }
+
+  private Long getSolvedTeamCount(Long challenge) {
+    return ctfFlagRepository.countByCtfChallengeEntityIdAndIsCorrect(challenge, true);
   }
 
   private CtfContestEntity getContest(Long ctfId) {

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -100,11 +100,11 @@ public class CtfChallengeService {
     if (flagEntity.isTooFastRetry(RETRY_SECONDS)) {
       throw new CustomTooFastRetryException(RETRY_SECONDS);
     }
-    flagEntity.updateLastTryTime();
+    LocalDateTime now = LocalDateTime.now();
+    flagEntity.updateLastTryTime(now);
     tryDecreaseSubmitCount(flagEntity);
     if (isFlagCorrect(submitFlag, flagEntity)) {
-      LocalDateTime solvedTime = LocalDateTime.now();
-      setCorrect(flagEntity, submitTeam, solvedTime);
+      setCorrect(flagEntity, submitTeam, now);
       updateTeamScore(submitChallenge, submitTeam);
       if (ctfUtilService.isTypeDynamic(submitChallenge)) {
         ctfUtilService.setDynamicScore(submitChallenge);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -37,6 +37,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CtfChallengeService {
 
+  /**
+   * 재전송 시간을 바꿀 경우 반드시 FE에 알려주어야 합니다.
+   * <p>
+   * RETRY_SECONDS가 바뀔 경우가 적다고 판단해서 API를 만드는 대신 FE와 함께 하드코딩 해놓았습니다.
+   */
   public static final long RETRY_SECONDS = 5;
 
   private final CtfChallengeRepository challengeRepository;

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfChallengeService.java
@@ -92,16 +92,16 @@ public class CtfChallengeService {
     Long submitterId = authService.getMemberIdByJWT();
     CtfTeamEntity submitTeam = getTeamEntity(getCtfIdByChallenge(submitChallenge), submitterId);
     CtfFlagEntity flagEntity = getFlagEntity(probId, submitTeam);
-    if (flagEntity.isTooFastRetry(RETRY_SECONDS)) {
-      throw new CustomTooFastRetryException(RETRY_SECONDS);
-    }
-    flagEntity.updateLastTryTime();
-    tryDecreaseSubmitCount(flagEntity);
     // 이미 맞췄으면 제출한 flag 정답 유무만 체크하고 DB 갱신 안함.
     if (isAlreadySolved(flagEntity)) {
       setSubmitFlagIsCorrect(submitFlag, flagEntity);
       return CtfFlagDto.toDto(flagEntity);
     }
+    if (flagEntity.isTooFastRetry(RETRY_SECONDS)) {
+      throw new CustomTooFastRetryException(RETRY_SECONDS);
+    }
+    flagEntity.updateLastTryTime();
+    tryDecreaseSubmitCount(flagEntity);
     if (isFlagCorrect(submitFlag, flagEntity)) {
       LocalDateTime solvedTime = LocalDateTime.now();
       setCorrect(flagEntity, submitTeam, solvedTime);

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -326,7 +326,12 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                         "TYPE이 DYNAMIC일 경우 minScore")
                     .optional(),
                 fieldWithPath("flag").description("문제의 flag"),
-                fieldWithPath("maxSubmitCount").description("각 팀당 가능한 최대 제출 횟수")
+                fieldWithPath("maxSubmitCount").description(
+                        String.format(
+                            "각 팀당 가능한 최대 제출 횟수 (%d이상 %d이하)%n%n만약 null로 보낸다면 DEFAULT 값(%d)이 들어갑니다.%n%n"
+                                + "최대, 최소값을 벗어나는 제출 횟수를 입력할 경우 success:false, code:400과 함께 msg에 에러 메시지가 담겨 나갑니다.",
+                            MIN_SUBMIT_COUNT, MAX_SUBMIT_COUNT, DEFAULT_SUBMIT_COUNT))
+                    .optional()
             ),
             responseFields(
                 generateChallengeAdminDtoResponseFields(ResponseType.SINGLE,

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -1,5 +1,11 @@
 package keeper.project.homepage.ctf.controller;
 
+import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.출제자;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회원;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회장;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberRankName.우수회원;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberRankName.일반회원;
+import static keeper.project.homepage.ApiControllerTestHelper.MemberTypeName.정회원;
 import static keeper.project.homepage.ctf.dto.CtfCommonChallengeDto.DEFAULT_SUBMIT_COUNT;
 import static keeper.project.homepage.ctf.dto.CtfCommonChallengeDto.MAX_SUBMIT_COUNT;
 import static keeper.project.homepage.ctf.dto.CtfCommonChallengeDto.MIN_SUBMIT_COUNT;
@@ -41,6 +47,7 @@ import keeper.project.homepage.member.entity.MemberEntity;
 import keeper.project.homepage.member.entity.MemberHasMemberJobEntity;
 import keeper.project.homepage.member.entity.MemberJobEntity;
 import keeper.project.homepage.util.service.CtfUtilService;
+import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,12 +77,11 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
 
   @BeforeEach
   public void setUp() throws Exception {
-    userEntity = generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원, MemberRankName.일반회원);
+    userEntity = generateMemberEntity(회원, 정회원, 일반회원);
     userToken = generateJWTToken(userEntity);
-    adminEntity = generateMemberEntity(MemberJobName.회장, MemberTypeName.정회원, MemberRankName.우수회원);
+    adminEntity = generateMemberEntity(회장, 정회원, 우수회원);
     adminToken = generateJWTToken(adminEntity);
-    makeProbUserEntity = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    makeProbUserEntity = generateMemberEntity(출제자, 정회원, 일반회원);
     makeProbUserToken = generateJWTToken(makeProbUserEntity);
     contestEntity = generateCtfContest(adminEntity);
   }
@@ -191,8 +197,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("회장 권한으로 문제 출제자 지정 - 성공")
   public void designateProbMakerSuccess() throws Exception {
-    MemberEntity probMaker = generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity probMaker = generateMemberEntity(회원, 정회원, 일반회원);
     CtfProbMakerDto probMakerDto = CtfProbMakerDto.builder()
         .memberId(probMaker.getId())
         .build();
@@ -220,8 +225,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("회장 권한으로 문제 출제자 삭제 - 성공")
   public void disqualifyProbMakerSuccess() throws Exception {
     // given
-    MemberEntity probMaker = generateMemberEntity(MemberJobName.회원, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity probMaker = generateMemberEntity(회원, 정회원, 일반회원);
     MemberJobEntity probMakerRole = memberJobRepository.findByName(
         CtfUtilService.PROBLEM_MAKER_JOB).get();
     memberHasMemberJobRepository.save(MemberHasMemberJobEntity.builder()
@@ -267,8 +271,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(DYNAMIC.getId()));
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     String creatorToken = generateJWTToken(creator);
     Long teamScore = 0L;
     generateCtfTeam(contestEntity, creator, teamScore);
@@ -284,18 +287,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Boolean isSolvable = true;
     Long score = 1234L;
     String flag = "flag{keeper}";
-    CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
-        .title(title)
-        .content(content)
-        .contestId(contestEntity.getId())
-        .category(category)
-        .type(type)
-        .isSolvable(isSolvable)
-        .score(score)
-        .dynamicInfo(dynamicInfo)
-        .flag(flag)
-        .maxSubmitCount(35L)
-        .build();
+    CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(35L,
+        category, type, creator, title, content, isSolvable, score, flag, dynamicInfo);
 
     mockMvc.perform(post("/v1/admin/ctf/prob")
             .header("Authorization", creatorToken)
@@ -349,8 +342,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     generateCtfTeam(contestEntity, creator, teamScore);
 
@@ -359,24 +351,10 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Boolean isSolvable = true;
     Long score = 1234L;
     String flag = "flag{keeper}";
-    CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
-        .title(title)
-        .content(content)
-        .contestId(contestEntity.getId())
-        .category(category)
-        .type(type)
-        .isSolvable(isSolvable)
-        .creatorName(creator.getNickName())
-        .score(score)
-        .flag(flag)
-        .maxSubmitCount(35L)
-        .build();
+    CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(35L,
+        category, type, creator, title, content, isSolvable, score, flag);
 
-    mockMvc.perform(post("/v1/admin/ctf/prob")
-            .header("Authorization", adminToken)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(asJsonString(challenge)))
-        .andDo(print())
+    createChallengeControllerTest(challenge)
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.code").value(0))
@@ -398,8 +376,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     generateCtfTeam(contestEntity, creator, teamScore);
 
@@ -408,23 +385,11 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Boolean isSolvable = true;
     Long score = 1234L;
     String flag = "flag{keeper}";
-    CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
-        .title(title)
-        .content(content)
-        .contestId(contestEntity.getId())
-        .category(category)
-        .type(type)
-        .isSolvable(isSolvable)
-        .creatorName(creator.getNickName())
-        .score(score)
-        .flag(flag)
-        .build();
 
-    mockMvc.perform(post("/v1/admin/ctf/prob")
-            .header("Authorization", adminToken)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(asJsonString(challenge)))
-        .andDo(print())
+    CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(
+        null, category, type, creator, title, content, isSolvable, score, flag);
+
+    createChallengeControllerTest(challenge)
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.code").value(0))
@@ -440,6 +405,15 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.maxSubmitCount").value(DEFAULT_SUBMIT_COUNT));
   }
 
+  @NonNull
+  private ResultActions createChallengeControllerTest(CtfChallengeAdminDto challenge) throws Exception {
+    return mockMvc.perform(post("/v1/admin/ctf/prob")
+            .header("Authorization", adminToken)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(challenge)))
+        .andDo(print());
+  }
+
   @ParameterizedTest
   @ValueSource(longs = {-10, 0, 1, 3, 15, 45, 50, 51, 123, Integer.MAX_VALUE})
   @DisplayName("회장 권한으로 STANDARD 문제 생성 - 성공")
@@ -448,8 +422,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     generateCtfTeam(contestEntity, creator, teamScore);
 
@@ -458,25 +431,11 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Boolean isSolvable = true;
     Long score = 1234L;
     String flag = "flag{keeper}";
-    CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
-        .title(title)
-        .content(content)
-        .contestId(contestEntity.getId())
-        .category(category)
-        .type(type)
-        .isSolvable(isSolvable)
-        .creatorName(creator.getNickName())
-        .score(score)
-        .flag(flag)
-        .maxSubmitCount(maxSubmitCount)
-        .build();
+    CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(
+        maxSubmitCount, category, type, creator, title, content, isSolvable, score, flag);
 
     if (MIN_SUBMIT_COUNT <= maxSubmitCount && maxSubmitCount <= MAX_SUBMIT_COUNT) {
-      mockMvc.perform(post("/v1/admin/ctf/prob")
-              .header("Authorization", adminToken)
-              .contentType(MediaType.APPLICATION_JSON)
-              .content(asJsonString(challenge)))
-          .andDo(print())
+      createChallengeControllerTest(challenge)
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.code").value(0))
@@ -490,16 +449,39 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
           .andExpect(jsonPath("$.data.score").value(score))
           .andExpect(jsonPath("$.data.flag").value(flag));
     } else {
-      mockMvc.perform(post("/v1/admin/ctf/prob")
-              .header("Authorization", adminToken)
-              .contentType(MediaType.APPLICATION_JSON)
-              .content(asJsonString(challenge)))
-          .andDo(print())
+      createChallengeControllerTest(challenge)
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.success").value(false))
           .andExpect(jsonPath("$.code").value(400));
     }
 
+  }
+
+  private CtfChallengeAdminDto generateCtfChallengeAdminDto(Long maxSubmitCount,
+      CtfChallengeCategoryDto category, CtfChallengeTypeDto type, MemberEntity creator,
+      String title, String content, Boolean isSolvable, Long score, String flag) {
+    return generateCtfChallengeAdminDto(
+        maxSubmitCount, category, type, creator, title, content, isSolvable, score, flag, null);
+  }
+
+  private CtfChallengeAdminDto generateCtfChallengeAdminDto(Long maxSubmitCount,
+      CtfChallengeCategoryDto category, CtfChallengeTypeDto type, MemberEntity creator,
+      String title, String content, Boolean isSolvable, Long score, String flag,
+      CtfDynamicChallengeInfoDto dynamicInfo) {
+    CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
+        .title(title)
+        .content(content)
+        .contestId(contestEntity.getId())
+        .category(category)
+        .type(type)
+        .isSolvable(isSolvable)
+        .creatorName(creator.getNickName())
+        .score(score)
+        .flag(flag)
+        .maxSubmitCount(maxSubmitCount)
+        .dynamicInfo(dynamicInfo)
+        .build();
+    return challenge;
   }
 
   @Test
@@ -508,8 +490,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png",
         "<<png data>>".getBytes());
     Long score = 1234L;
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, DYNAMIC, FORENSIC, score,
-        true);
+    CtfChallengeEntity challenge = generateCtfChallenge(
+        contestEntity, DYNAMIC, FORENSIC, score, true);
     mockMvc.perform(multipart("/v1/admin/ctf/prob/file")
             .file(file)
             .param("challengeId", String.valueOf(challenge.getId()))
@@ -537,13 +519,12 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("문제 오픈 - 성공")
   public void openProblemSuccess() throws Exception {
 
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, MISC, score,
-        false);
+    CtfChallengeEntity challenge = generateCtfChallenge(
+        contestEntity, STANDARD, MISC, score, false);
     generateCtfFlag(team, challenge, false);
 
     mockMvc.perform(patch("/v1/admin/ctf/prob/{pid}/open", challenge.getId())
@@ -572,14 +553,12 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("문제 닫기 - 성공")
   public void closeProblemSuccess() throws Exception {
 
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity,
-        STANDARD,
-        MISC, score, false);
+    CtfChallengeEntity challenge = generateCtfChallenge(
+        contestEntity, STANDARD, MISC, score, false);
     generateCtfFlag(team, challenge, false);
 
     mockMvc.perform(patch("/v1/admin/ctf/prob/{pid}/close", challenge.getId())
@@ -608,8 +587,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("회장 권한으로 문제 삭제 - 성공")
   public void deleteProblemSuccess() throws Exception {
     // given
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
@@ -646,14 +624,13 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("문제 삭제 시 해당 문제를 푼 팀의 점수 롤백 (STANDARD TYPE) - 성공")
   public void deleteStandardProblemScoreRollbackSuccess() throws Exception {
     // given
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     creator.addMemberJob(memberJobRepository.findByName("ROLE_회원").get());
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity,
-        STANDARD, MISC, score, true);
+    CtfChallengeEntity challenge = generateCtfChallenge(
+        contestEntity, STANDARD, MISC, score, true);
     CtfFlagEntity flag = generateCtfFlag(team, challenge, false);
 
     // when
@@ -685,8 +662,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("문제 삭제 시 해당 문제를 푼 팀의 점수 롤백 (DYNAMIC TYPE) - 성공")
   public void deleteDynamicProblemScoreRollbackSuccess() throws Exception {
     // given
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     creator.addMemberJob(memberJobRepository.findByName("ROLE_회원").get());
     Long teamScore = 0L;
     Long score = 1234L;
@@ -750,18 +726,15 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("출제자 권한으로 문제 목록 불러오기 - 성공")
   public void getProblemListSuccess() throws Exception {
     // given
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     String probMakerToken = generateJWTToken(creator);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity,
-        STANDARD,
-        MISC, score, false);
-    CtfChallengeEntity challenge2 = generateCtfChallenge(contestEntity,
-        DYNAMIC,
-        FORENSIC, score, false);
+    CtfChallengeEntity challenge = generateCtfChallenge(
+        contestEntity, STANDARD, MISC, score, false);
+    CtfChallengeEntity challenge2 = generateCtfChallenge(
+        contestEntity, DYNAMIC, FORENSIC, score, false);
     generateDynamicChallengeInfo(challenge2, 1000L, 100L);
     generateCtfFlag(team, challenge2, false);
     generateCtfFlag(team, challenge, false);
@@ -800,18 +773,15 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("출제자 권한으로 로그 목록 불러오기 - 성공")
   public void getSubmitLogListSuccess() throws Exception {
     // given
-    MemberEntity creator = generateMemberEntity(MemberJobName.출제자, MemberTypeName.정회원,
-        MemberRankName.일반회원);
+    MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     String probMakerToken = generateJWTToken(creator);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity,
-        STANDARD,
-        MISC, score, false);
-    CtfChallengeEntity challenge2 = generateCtfChallenge(contestEntity,
-        DYNAMIC,
-        FORENSIC, score, false);
+    CtfChallengeEntity challenge = generateCtfChallenge(
+        contestEntity, STANDARD, MISC, score, false);
+    CtfChallengeEntity challenge2 = generateCtfChallenge(
+        contestEntity, DYNAMIC, FORENSIC, score, false);
     generateDynamicChallengeInfo(challenge2, 1000L, 100L);
     generateCtfFlag(team, challenge2, false);
     generateCtfFlag(team, challenge, false);

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -291,7 +291,9 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
-            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. "),
+            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. \n\n"
+            + "해당 필드가 만들어지기 전의 문제들은 null값을 보냅니다.")
+            .optional(),
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id")
     ));
     if (addDescriptors.length > 0) {

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -291,8 +291,12 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
-            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. \n\n"
-            + "해당 필드가 만들어지기 전의 문제들은 null값을 보냅니다.")
+                + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. \n\n"
+                + "해당 필드가 만들어지기 전의 문제들은 null값을 보냅니다.")
+            .optional(),
+        fieldWithPath(prefix + ".solvedTime").description(
+                "각 팀별 문제를 해결한 시간입니다. 만약 해결하지 않았다면 null 값을 보냅니다. \n\n"
+                    + "해당 필드가 만들어지기 전의 문제들은 해결이 되었어도 null값을 보냅니다.")
             .optional(),
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id")
     ));
@@ -324,7 +328,13 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
-            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다."),
+                + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. \n\n"
+                + "해당 필드가 만들어지기 전의 문제들은 null값을 보냅니다.")
+            .optional(),
+        fieldWithPath(prefix + ".solvedTime").description(
+                "각 팀별 문제를 해결한 시간입니다. 만약 해결하지 않았다면 null 값을 보냅니다. \n\n"
+                    + "해당 필드가 만들어지기 전의 문제들은 해결이 되었어도 null값을 보냅니다.")
+            .optional(),
         subsectionWithPath(prefix + ".dynamicInfo").description("TYPE이 STANDARD일 경우 null")
             .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
@@ -367,7 +377,13 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
         fieldWithPath(prefix + ".remainedSubmitCount").description("남은 제출 횟수"),
         fieldWithPath(prefix + ".lastTryTime").description("각 팀별 마지막 제출 시간입니다. 만약 " + RETRY_SECONDS
-            + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다."),
+                + "초 내에 다시 시도할 경우 프론트에서 API 호출을 막아주는게 좋습니다. \n\n"
+                + "해당 필드가 만들어지기 전의 문제들은 null값을 보냅니다.")
+            .optional(),
+        fieldWithPath(prefix + ".solvedTime").description(
+                "각 팀별 문제를 해결한 시간입니다. 만약 해결하지 않았다면 null 값을 보냅니다. \n\n"
+                    + "해당 필드가 만들어지기 전의 문제들은 해결이 되었어도 null값을 보냅니다.")
+            .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()
     ));
     if (type.equals(ResponseType.PAGE)) {

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -335,6 +335,9 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
                 "각 팀별 문제를 해결한 시간입니다. 만약 해결하지 않았다면 null 값을 보냅니다. \n\n"
                     + "해당 필드가 만들어지기 전의 문제들은 해결이 되었어도 null값을 보냅니다.")
             .optional(),
+        fieldWithPath(prefix + ".isSolved").description("관리자 권한의 isSolved는 항상 null로 주어집니다.")
+            .optional(),
+        fieldWithPath(prefix + ".solvedTeamCount").description("문제를 푼 팀의 수"),
         subsectionWithPath(prefix + ".dynamicInfo").description("TYPE이 STANDARD일 경우 null")
             .optional(),
         subsectionWithPath(prefix + ".file").description("문제에 해당하는 파일 정보").optional()


### PR DESCRIPTION
## 연관 issue

close : #467

- #467 

## 프론트 전달사항

1. 최대 제출 가능 횟수 50번 / 최소 제출 가능 횟수 1번 / default 15번으로 변경
    - CTF 관리자 API -> 문제 생성 -> maxSubmitCount 필드 수정
    <img width="980" alt="image" src="https://user-images.githubusercontent.com/26597702/206596952-678b3e40-8ba3-42ad-add6-8258bfd1b8da.png">


2. 재전송 시간 "5초"는 회장 권한으로 바꿀 수 있었는데, 현재 백엔드에 하드코딩 되어 있음. 이를 API로 프론트에 넘겨줄까 하다가 자주 수정될 것 같지 않아서 주석으로 "수정 시 FE에 알려주기" 를 달려고 함
3. CTF 문제 API에 `lastTryTime` 문구 변경 + `solvedTime` 필드 추가
    <img width="983" alt="image" src="https://user-images.githubusercontent.com/26597702/206596709-38981bae-cba9-4980-86f8-fc5e01b3595e.png">
4. 맞춘 문제는 서버측에서도 시도 횟수를 차감 하지 않고 `lastTryTime`을 갱신시키지도 않도록 변경
5. 맞춘 문제의 solveTime과 lastTryTime이 살짝 다른 문제 해결
6. 관리자 문제 정보에 누락된 문제를 푼 팀 수 필드 추가 + `isSolved` 필드는 항상 `null`로 전달됨
    <img width="982" alt="image" src="https://user-images.githubusercontent.com/26597702/206597218-46049720-ade1-47da-bdba-f2e9367e937f.png">