### PR TITLE
Feature/#469 ctf 문제 삭제시 포인트 롤백안되는 버그 해결

### DIFF
--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -5,7 +5,6 @@ import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLE
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_TEAM_ID;
 
 import java.nio.file.AccessDeniedException;
-import java.time.LocalDateTime;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
@@ -304,7 +303,7 @@ public class CtfAdminService {
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
           .remainedSubmitCount(maxSubmitCount)
-          .lastTryTime(LocalDateTime.now())
+          .lastTryTime(null)
           .build();
       ctfFlagRepository.save(flagEntity);
       challenge.getCtfFlagEntity().add(flagEntity);

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfTeamService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfTeamService.java
@@ -250,6 +250,7 @@ public class CtfTeamService {
           .ctfTeamEntity(newTeamEntity)
           .ctfChallengeEntity(challenge)
           .isCorrect(false)
+          .remainedSubmitCount(challenge.getMaxSubmitCount())
           .build();
       flagRepository.save(flagEntity);
     });

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -52,20 +52,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 생성 테스트")
   void createChallenge() {
-    CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
-        .isSolvable(true)
-        .flag("flag")
-        .type(getStandardType())
-        .dynamicInfo(null)
-        .content("content")
-        .title("title")
-        .score(1234L)
-        .category(getWebCategory())
-        .contestId(ctfContestEntity.getId())
-        .maxSubmitCount(123L)
-        .build();
-
-    CtfChallengeAdminDto result = ctfAdminService.createChallenge(challengeAdminDto);
+    CtfChallengeAdminDto result = createStandardChallenge(1234L);
     CtfFlagEntity flag = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
         result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
 
@@ -83,6 +70,23 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     assertThat(flag.getIsCorrect()).isEqualTo(false);
 
 
+  }
+
+  private CtfChallengeAdminDto createStandardChallenge(long score) {
+    CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
+        .isSolvable(true)
+        .flag("flag")
+        .type(getStandardType())
+        .dynamicInfo(null)
+        .content("content")
+        .title("title")
+        .score(score)
+        .category(getWebCategory())
+        .contestId(ctfContestEntity.getId())
+        .maxSubmitCount(123L)
+        .build();
+
+    return ctfAdminService.createChallenge(challengeAdminDto);
   }
 
   private static CtfChallengeCategoryDto getWebCategory() {

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -1,5 +1,6 @@
 package keeper.project.homepage.ctf.service;
 
+import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회원;
 import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회장;
 import static keeper.project.homepage.ApiControllerTestHelper.MemberRankName.일반회원;
 import static keeper.project.homepage.ApiControllerTestHelper.MemberTypeName.정회원;
@@ -7,11 +8,16 @@ import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfC
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.AccessDeniedException;
 import java.util.List;
+import java.util.UUID;
+import javax.persistence.EntityManager;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
+import keeper.project.homepage.ctf.dto.CtfFlagDto;
+import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
@@ -31,12 +37,19 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
 
   @Autowired
   private CtfAdminService ctfAdminService;
+  @Autowired
+  private CtfChallengeService ctfChallengeService;
+  @Autowired
+  private CtfTeamService ctfTeamService;
+  @Autowired
+  EntityManager em;
 
   private CtfContestEntity ctfContestEntity;
+  private MemberEntity contestCreator;
 
   @BeforeEach
   void setUp() {
-    MemberEntity contestCreator = generateMemberEntity(회장, 정회원, 일반회원);
+    contestCreator = generateMemberEntity(회장, 정회원, 일반회원);
     setAuthentication(contestCreator, 회장);
     ctfContestEntity = generateCtfContest(contestCreator);
   }
@@ -52,7 +65,7 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 생성 테스트")
   void createChallenge() {
-    CtfChallengeAdminDto result = createStandardChallenge(1234L);
+    CtfChallengeAdminDto result = createStandardChallenge(1234L, "flag", "content", "title", 123L);
     CtfFlagEntity flag = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
         result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
 
@@ -68,22 +81,26 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     assertThat(result.getContestId()).isEqualTo(ctfContestEntity.getId());
     assertThat(flag.getRemainedSubmitCount()).isEqualTo(123L);
     assertThat(flag.getIsCorrect()).isEqualTo(false);
-
-
   }
 
   private CtfChallengeAdminDto createStandardChallenge(long score) {
+    return createStandardChallenge(score, getRandomUUID(), getRandomUUID(), getRandomUUID(), 15L);
+  }
+
+  private CtfChallengeAdminDto createStandardChallenge(long score, String flag, String content,
+      String title, long maxSubmitCount) {
+    setAuthentication(contestCreator, 회장);
     CtfChallengeAdminDto challengeAdminDto = CtfChallengeAdminDto.builder()
         .isSolvable(true)
-        .flag("flag")
+        .flag(flag)
         .type(getStandardType())
         .dynamicInfo(null)
-        .content("content")
-        .title("title")
+        .content(content)
+        .title(title)
         .score(score)
         .category(getWebCategory())
         .contestId(ctfContestEntity.getId())
-        .maxSubmitCount(123L)
+        .maxSubmitCount(maxSubmitCount)
         .build();
 
     return ctfAdminService.createChallenge(challengeAdminDto);
@@ -101,5 +118,100 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
         .id(STANDARD.getId())
         .name(STANDARD.getName())
         .build();
+  }
+
+  @Test
+  @DisplayName("[시나리오1] STANDRAD 문제 삭제 시 점수 반영 제대로 되는지 테스트")
+  void deleteProblem_scenario1() {
+    CtfChallengeAdminDto challenge1 = createStandardChallenge(100L);
+    CtfChallengeAdminDto challenge2 = createStandardChallenge(200L);
+    CtfChallengeAdminDto challenge3 = createStandardChallenge(400L);
+
+    MemberEntity user1 = generateMemberEntity(회원, 정회원, 일반회원);
+    CtfTeamDetailDto team1 = createCtfTeam(user1); // 1번, 2번 문제 해결
+    MemberEntity user2 = generateMemberEntity(회원, 정회원, 일반회원);
+    CtfTeamDetailDto team2 = createCtfTeam(user2); // 2번, 3번 문제 해결
+    MemberEntity user3 = generateMemberEntity(회원, 정회원, 일반회원);
+    CtfTeamDetailDto team3 = createCtfTeam(user3); // 1번, 2번, 3번 모두 해결
+
+    assertThat(solveChallenge(challenge1, user1)).isTrue();
+    assertThat(solveChallenge(challenge2, user1)).isTrue();
+    assertThat(solveChallenge(challenge2, user2)).isTrue();
+    assertThat(solveChallenge(challenge3, user2)).isTrue();
+    assertThat(solveChallenge(challenge1, user3)).isTrue();
+    assertThat(solveChallenge(challenge2, user3)).isTrue();
+    assertThat(solveChallenge(challenge3, user3)).isTrue();
+
+    assertThat(ctfTeamRepository.getById(team1.getId()).getScore()).isEqualTo(300L);
+    assertThat(ctfTeamRepository.getById(team2.getId()).getScore()).isEqualTo(600L);
+    assertThat(ctfTeamRepository.getById(team3.getId()).getScore()).isEqualTo(700L);
+
+    em.flush();
+    em.clear();
+
+    deleteCtfChallenge(challenge1.getChallengeId());
+    assertThat(ctfTeamRepository.getById(team1.getId()).getScore()).isEqualTo(200L);
+    assertThat(ctfTeamRepository.getById(team2.getId()).getScore()).isEqualTo(600L);
+    assertThat(ctfTeamRepository.getById(team3.getId()).getScore()).isEqualTo(600L);
+
+    deleteCtfChallenge(challenge2.getChallengeId());
+    assertThat(ctfTeamRepository.getById(team1.getId()).getScore()).isEqualTo(0L);
+    assertThat(ctfTeamRepository.getById(team2.getId()).getScore()).isEqualTo(400L);
+    assertThat(ctfTeamRepository.getById(team3.getId()).getScore()).isEqualTo(400L);
+
+    CtfChallengeAdminDto challenge4 = createStandardChallenge(800L);
+
+    assertThat(solveChallenge(challenge4, user1)).isTrue();
+    assertThat(solveChallenge(challenge4, user2)).isTrue();
+
+    assertThat(ctfTeamRepository.getById(team1.getId()).getScore()).isEqualTo(800L);
+    assertThat(ctfTeamRepository.getById(team2.getId()).getScore()).isEqualTo(1200L);
+    assertThat(ctfTeamRepository.getById(team3.getId()).getScore()).isEqualTo(400L);
+
+    em.flush();
+    em.clear();
+
+    deleteCtfChallenge(challenge3.getChallengeId());
+    assertThat(ctfTeamRepository.getById(team1.getId()).getScore()).isEqualTo(800L);
+    assertThat(ctfTeamRepository.getById(team2.getId()).getScore()).isEqualTo(800L);
+    assertThat(ctfTeamRepository.getById(team3.getId()).getScore()).isEqualTo(0L);
+
+    deleteCtfChallenge(challenge4.getChallengeId());
+    assertThat(ctfTeamRepository.getById(team1.getId()).getScore()).isEqualTo(0L);
+    assertThat(ctfTeamRepository.getById(team2.getId()).getScore()).isEqualTo(0L);
+    assertThat(ctfTeamRepository.getById(team3.getId()).getScore()).isEqualTo(0L);
+  }
+
+  private void deleteCtfChallenge(long challengeId) {
+    setAuthentication(contestCreator, 회장);
+    try {
+      ctfAdminService.deleteProblem(challengeId);
+    } catch (AccessDeniedException e) {
+      throw new RuntimeException("내가 왜 검사 예외를 썼을까... ㅠㅠㅠ", e);
+    }
+  }
+
+  private CtfTeamDetailDto createCtfTeam(MemberEntity teamLeader) {
+    setAuthentication(teamLeader, 회원);
+    return ctfTeamService.createTeam(CtfTeamDetailDto.builder()
+        .contestId(ctfContestEntity.getId())
+        .name(getRandomUUID())
+        .description(getRandomUUID())
+        .build()
+    );
+  }
+
+  private boolean solveChallenge(CtfChallengeAdminDto challengeInfo, MemberEntity solvedUser) {
+    setAuthentication(solvedUser, 회원);
+    CtfFlagDto result = ctfChallengeService.checkFlag(challengeInfo.getChallengeId(),
+        CtfFlagDto.builder()
+            .content(challengeInfo.getFlag())
+            .build()
+    );
+    return result.getIsCorrect();
+  }
+
+  private static String getRandomUUID() {
+    return UUID.randomUUID().toString();
   }
 }


### PR DESCRIPTION
처음으로 시나리오를 담아서 통합 테스트를 만들어봤네요..!!

문제 삭제시 포인트 롤백이 안되는 버그가 있어서(정확하게는 푼 문제들의 점수 총합과 팀의 점수가 다른 버그) 해당 시나리오로 통합테스트를 해봤는데, 문제는 찾지 못했습니다... ㅠㅠ

이것도 isolation 문제 같긴 한데, 로그가 없으니 어디서 문제가 생겼고 이런걸 도저히 찾을수가 없네요 ㅠㅠ

## 연관 issue

close : #469 

- #469

## 프론트 전달사항

팀 생성시 `lastTryTime`이 팀 생성시간으로 보내지던게 이제 `null`로 보내집니다.