### PR TITLE
Feature/ctf 카테고리 여러개로 설정되도록 변경

### DIFF
--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -71,8 +71,8 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .content(challenge.getDescription())
         .contestId(challenge.getCtfContestEntity().getId())
         .category(challenge.getCtfChallengeHasCtfChallengeCategoryList().stream()
-            .map(CtfChallengeCategoryDto::toDto).collect(
-                toList()))
+            .map(CtfChallengeCategoryDto::toDto)
+            .collect(toList()))
         .type(type)
         .flag(getVirtualTeamFlag(challenge).getContent())
         .isSolvable(challenge.getIsSolvable())

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -1,5 +1,7 @@
 package keeper.project.homepage.ctf.dto;
 
+import static java.util.stream.Collectors.toList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -38,12 +40,12 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
   private CtfDynamicChallengeInfoDto dynamicInfo;
 
   public CtfChallengeEntity toEntity(CtfContestEntity contest, CtfChallengeTypeEntity type,
-      CtfChallengeCategoryEntity category, FileEntity fileEntity, MemberEntity creator) {
+      FileEntity fileEntity, MemberEntity creator) {
     return CtfChallengeEntity.builder()
         .name(title)
         .description(content)
         .ctfContestEntity(contest)
-        .ctfChallengeCategoryEntity(category)
+        .ctfChallengeHasCtfChallengeCategoryList(new ArrayList<>())
         .ctfChallengeTypeEntity(type)
         .isSolvable(isSolvable)
         .registerTime(LocalDateTime.now())
@@ -56,8 +58,6 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
   }
 
   public static CtfChallengeAdminDto toDto(CtfChallengeEntity challenge, Long solvedTeamCount) {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        challenge.getCtfChallengeCategoryEntity());
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         challenge.getCtfChallengeTypeEntity());
     FileDto file = FileDto.toDto(
@@ -70,7 +70,9 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .title(challenge.getName())
         .content(challenge.getDescription())
         .contestId(challenge.getCtfContestEntity().getId())
-        .category(category)
+        .category(challenge.getCtfChallengeHasCtfChallengeCategoryList().stream()
+            .map(CtfChallengeCategoryDto::toDto).collect(
+                toList()))
         .type(type)
         .flag(getVirtualTeamFlag(challenge).getContent())
         .isSolvable(challenge.getIsSolvable())

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeAdminDto.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
@@ -70,7 +69,7 @@ public class CtfChallengeAdminDto extends CtfChallengeDto {
         .title(challenge.getName())
         .content(challenge.getDescription())
         .contestId(challenge.getCtfContestEntity().getId())
-        .category(challenge.getCtfChallengeHasCtfChallengeCategoryList().stream()
+        .categories(challenge.getCtfChallengeHasCtfChallengeCategoryList().stream()
             .map(CtfChallengeCategoryDto::toDto)
             .collect(toList()))
         .type(type)

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeCategoryDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeCategoryDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeHasCtfChallengeCategoryEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,10 +25,24 @@ public class CtfChallengeCategoryDto {
   @JsonProperty(access = Access.READ_ONLY)
   private String name;
 
+  public static CtfChallengeCategoryEntity toEntity(CtfChallengeCategoryDto ctfChallengeCategoryDto){
+    return CtfChallengeCategoryEntity.builder()
+        .id(ctfChallengeCategoryDto.getId())
+        .name(ctfChallengeCategoryDto.getName())
+        .build();
+  }
+
   public static CtfChallengeCategoryDto toDto(CtfChallengeCategoryEntity ctfChallengeCategoryEntity) {
     return CtfChallengeCategoryDto.builder()
         .id(ctfChallengeCategoryEntity.getId())
         .name(ctfChallengeCategoryEntity.getName())
+        .build();
+  }
+
+  public static CtfChallengeCategoryDto toDto(CtfChallengeHasCtfChallengeCategoryEntity ctfChallengeHasCtfChallengeCategoryEntity) {
+    return CtfChallengeCategoryDto.builder()
+        .id(ctfChallengeHasCtfChallengeCategoryEntity.getCategory().getId())
+        .name(ctfChallengeHasCtfChallengeCategoryEntity.getCategory().getName())
         .build();
   }
 }

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -1,5 +1,7 @@
 package keeper.project.homepage.ctf.dto;
 
+import static java.util.stream.Collectors.toList;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,8 +34,6 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
 
   public static CtfChallengeDto toDto(CtfChallengeEntity challenge, Long solvedTeamCount,
       Boolean isSolved, CtfFlagEntity ctfFlagEntity) {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        challenge.getCtfChallengeCategoryEntity());
     FileDto file = FileDto.toDto(challenge.getFileEntity());
 
     return CtfChallengeDto.builder()
@@ -41,7 +41,10 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .title(challenge.getName())
         .content(challenge.getDescription())
         .contestId(challenge.getCtfContestEntity().getId())
-        .category(category)
+        .category(challenge.getCtfChallengeHasCtfChallengeCategoryList()
+            .stream()
+            .map(CtfChallengeCategoryDto::toDto)
+            .collect(toList()))
         .creatorName(challenge.getCreator().getNickName())
         .score(challenge.getScore())
         .solvedTeamCount(solvedTeamCount)

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfChallengeDto.java
@@ -3,7 +3,6 @@ package keeper.project.homepage.ctf.dto;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
@@ -41,7 +40,7 @@ public class CtfChallengeDto extends CtfCommonChallengeDto {
         .title(challenge.getName())
         .content(challenge.getDescription())
         .contestId(challenge.getCtfContestEntity().getId())
-        .category(challenge.getCtfChallengeHasCtfChallengeCategoryList()
+        .categories(challenge.getCtfChallengeHasCtfChallengeCategoryList()
             .stream()
             .map(CtfChallengeCategoryDto::toDto)
             .collect(toList()))

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
@@ -32,7 +31,7 @@ public class CtfCommonChallengeDto {
 
   protected String title;
   protected Long score;
-  protected List<CtfChallengeCategoryDto> category;
+  protected List<CtfChallengeCategoryDto> categories;
   protected Long contestId;
   @Max(MAX_SUBMIT_COUNT)
   @Min(MIN_SUBMIT_COUNT)
@@ -57,7 +56,7 @@ public class CtfCommonChallengeDto {
         .challengeId(challenge.getId())
         .title(challenge.getName())
         .contestId(challenge.getCtfContestEntity().getId())
-        .category(challenge.getCtfChallengeHasCtfChallengeCategoryList()
+        .categories(challenge.getCtfChallengeHasCtfChallengeCategoryList()
             .stream()
             .map(CtfChallengeCategoryDto::toDto)
             .collect(toList()))

--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -1,10 +1,14 @@
 package keeper.project.homepage.ctf.dto;
 
+import static java.util.stream.Collectors.toList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
@@ -28,7 +32,7 @@ public class CtfCommonChallengeDto {
 
   protected String title;
   protected Long score;
-  protected CtfChallengeCategoryDto category;
+  protected List<CtfChallengeCategoryDto> category;
   protected Long contestId;
   @Max(MAX_SUBMIT_COUNT)
   @Min(MIN_SUBMIT_COUNT)
@@ -48,14 +52,15 @@ public class CtfCommonChallengeDto {
 
   public static CtfCommonChallengeDto toDto(CtfChallengeEntity challenge, Boolean isSolved,
       CtfFlagEntity ctfFlagEntity) {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        challenge.getCtfChallengeCategoryEntity());
 
     return CtfCommonChallengeDto.builder()
         .challengeId(challenge.getId())
         .title(challenge.getName())
         .contestId(challenge.getCtfContestEntity().getId())
-        .category(category)
+        .category(challenge.getCtfChallengeHasCtfChallengeCategoryList()
+            .stream()
+            .map(CtfChallengeCategoryDto::toDto)
+            .collect(toList()))
         .score(challenge.getScore())
         .isSolved(isSolved)
         .remainedSubmitCount(ctfFlagEntity.getRemainedSubmitCount())

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeEntity.java
@@ -57,10 +57,9 @@ public class CtfChallengeEntity {
   @JoinColumn(name = "type_id", nullable = false)
   CtfChallengeTypeEntity ctfChallengeTypeEntity;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "category_id", nullable = false)
-  CtfChallengeCategoryEntity ctfChallengeCategoryEntity;
-
+  @Builder.Default
+  @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
+  List<CtfChallengeHasCtfChallengeCategoryEntity> ctfChallengeHasCtfChallengeCategoryList = new ArrayList<>();
   @Column(nullable = false)
   @Setter
   Long score;

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeEntity.java
@@ -60,6 +60,7 @@ public class CtfChallengeEntity {
   @Builder.Default
   @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
   List<CtfChallengeHasCtfChallengeCategoryEntity> ctfChallengeHasCtfChallengeCategoryList = new ArrayList<>();
+
   @Column(nullable = false)
   @Setter
   Long score;
@@ -89,4 +90,8 @@ public class CtfChallengeEntity {
   @PrimaryKeyJoinColumn
   @Setter
   CtfDynamicChallengeInfoEntity dynamicChallengeInfoEntity;
+
+  public void addCtfChallengeHasCtfChallengeCategory(CtfChallengeHasCtfChallengeCategoryEntity ctfChallengeHasCtfChallengeCategoryEntity) {
+    this.getCtfChallengeHasCtfChallengeCategoryList().add(ctfChallengeHasCtfChallengeCategoryEntity);
+  }
 }

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeHasCtfChallengeCategoryEntity.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeHasCtfChallengeCategoryEntity.java
@@ -1,0 +1,35 @@
+package keeper.project.homepage.ctf.entity;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(CtfChallengeHasCtfChallengeCategoryEntityPK.class) // 정의한 idclass 주입
+@Table(name = "ctf_challenge_has_ctf_challenge_category")
+public class CtfChallengeHasCtfChallengeCategoryEntity implements Serializable {
+
+  @Id
+  @ManyToOne(targetEntity = CtfChallengeEntity.class, fetch = FetchType.LAZY)
+  @JoinColumn(name = "ctf_challenge_id")
+  private CtfChallengeEntity challenge;
+
+  @Id
+  @ManyToOne(targetEntity = CtfChallengeCategoryEntity.class, fetch = FetchType.LAZY)
+  @JoinColumn(name = "ctf_challenge_category_id")
+  private CtfChallengeCategoryEntity category;
+
+}

--- a/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeHasCtfChallengeCategoryEntityPK.java
+++ b/src/main/java/keeper/project/homepage/ctf/entity/CtfChallengeHasCtfChallengeCategoryEntityPK.java
@@ -1,0 +1,19 @@
+package keeper.project.homepage.ctf.entity;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CtfChallengeHasCtfChallengeCategoryEntityPK implements Serializable {
+
+  private Long challenge;
+  private Long category;
+}

--- a/src/main/java/keeper/project/homepage/ctf/repository/CtfChallengeHasCtfChallengeCategoryRepository.java
+++ b/src/main/java/keeper/project/homepage/ctf/repository/CtfChallengeHasCtfChallengeCategoryRepository.java
@@ -1,0 +1,10 @@
+package keeper.project.homepage.ctf.repository;
+
+import keeper.project.homepage.ctf.entity.CtfChallengeHasCtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeHasCtfChallengeCategoryEntityPK;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CtfChallengeHasCtfChallengeCategoryRepository extends
+    JpaRepository<CtfChallengeHasCtfChallengeCategoryEntity, CtfChallengeHasCtfChallengeCategoryEntityPK> {
+
+}

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -5,15 +5,19 @@ import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLE
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_TEAM_ID;
 
 import java.nio.file.AccessDeniedException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfContestAdminDto;
 import keeper.project.homepage.ctf.dto.CtfDynamicChallengeInfoDto;
 import keeper.project.homepage.ctf.dto.CtfProbMakerDto;
 import keeper.project.homepage.ctf.dto.CtfSubmitLogDto;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeHasCtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfDynamicChallengeInfoEntity;
@@ -24,6 +28,7 @@ import keeper.project.homepage.ctf.exception.CustomCtfCategoryNotFoundException;
 import keeper.project.homepage.ctf.exception.CustomCtfChallengeNotFoundException;
 import keeper.project.homepage.ctf.exception.CustomCtfTypeNotFoundException;
 import keeper.project.homepage.ctf.repository.CtfChallengeCategoryRepository;
+import keeper.project.homepage.ctf.repository.CtfChallengeHasCtfChallengeCategoryRepository;
 import keeper.project.homepage.ctf.repository.CtfChallengeRepository;
 import keeper.project.homepage.ctf.repository.CtfChallengeTypeRepository;
 import keeper.project.homepage.ctf.repository.CtfContestRepository;
@@ -63,6 +68,8 @@ public class CtfAdminService {
   private final CtfContestRepository ctfContestRepository;
   private final CtfTeamRepository ctfTeamRepository;
   private final CtfChallengeCategoryRepository ctfChallengeCategoryRepository;
+
+  private final CtfChallengeHasCtfChallengeCategoryRepository ctfChallengeHasCtfChallengeCategoryRepository;
   private final CtfSubmitLogRepository ctfSubmitLogRepository;
   private final CtfChallengeTypeRepository ctfChallengeTypeRepository;
   private final CtfChallengeRepository challengeRepository;
@@ -111,6 +118,8 @@ public class CtfAdminService {
   @Transactional
   public CtfChallengeAdminDto createChallenge(CtfChallengeAdminDto challengeAdminDto) {
     CtfChallengeEntity newChallenge = createChallengeEntity(challengeAdminDto);
+
+    setChallengeCategory(newChallenge, challengeAdminDto);
     if (ctfUtilService.isTypeDynamic(newChallenge)) {
       trySetDynamicInfoInChallenge(newChallenge, challengeAdminDto);
     }
@@ -317,12 +326,30 @@ public class CtfAdminService {
   private CtfChallengeEntity createChallengeEntityWithFileEntity(
       CtfChallengeAdminDto challengeAdminDto, FileEntity fileEntity) {
     CtfContestEntity contest = getCtfContestEntity(challengeAdminDto.getContestId());
-    CtfChallengeCategoryEntity category = getCategoryEntity(challengeAdminDto);
+
     CtfChallengeTypeEntity type = getTypeEntity(challengeAdminDto);
     MemberEntity creator = authService.getMemberEntityWithJWT();
+
     CtfChallengeEntity challenge = challengeAdminDto
-        .toEntity(contest, type, category, fileEntity, creator);
+        .toEntity(contest, type, fileEntity, creator);
+
     return challengeRepository.save(challenge);
+  }
+
+  private void setChallengeCategory(CtfChallengeEntity challenge,
+      CtfChallengeAdminDto challengeAdminDto) {
+    List<CtfChallengeCategoryEntity> ctfChallengeCategoryEntityList = challengeAdminDto.getCategory()
+        .stream()
+        .map(CtfChallengeCategoryDto::toEntity).toList();
+
+    for (CtfChallengeCategoryEntity ctfChallengeCategory : ctfChallengeCategoryEntityList) {
+      CtfChallengeHasCtfChallengeCategoryEntity save = ctfChallengeHasCtfChallengeCategoryRepository.save(
+          CtfChallengeHasCtfChallengeCategoryEntity.builder()
+              .challenge(challenge)
+              .category(ctfChallengeCategory)
+              .build());
+      challenge.getCtfChallengeHasCtfChallengeCategoryList().add(save);
+    }
   }
 
   private CtfChallengeEntity createChallengeEntity(CtfChallengeAdminDto challengeAdminDto) {
@@ -335,9 +362,10 @@ public class CtfAdminService {
         .orElseThrow(CustomCtfTypeNotFoundException::new);
   }
 
-  private CtfChallengeCategoryEntity getCategoryEntity(CtfChallengeAdminDto challengeAdminDto) {
+  private CtfChallengeCategoryEntity getCategoryEntity(
+      CtfChallengeCategoryDto ctfChallengeCategoryDto) {
     return ctfChallengeCategoryRepository
-        .findById(challengeAdminDto.getCategory().getId())
+        .findById(ctfChallengeCategoryDto.getId())
         .orElseThrow(CustomCtfCategoryNotFoundException::new);
   }
 

--- a/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
+++ b/src/main/java/keeper/project/homepage/ctf/service/CtfAdminService.java
@@ -5,9 +5,7 @@ import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_PROBLE
 import static keeper.project.homepage.util.service.CtfUtilService.VIRTUAL_TEAM_ID;
 
 import java.nio.file.AccessDeniedException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
@@ -338,17 +336,17 @@ public class CtfAdminService {
 
   private void setChallengeCategory(CtfChallengeEntity challenge,
       CtfChallengeAdminDto challengeAdminDto) {
-    List<CtfChallengeCategoryEntity> ctfChallengeCategoryEntityList = challengeAdminDto.getCategory()
+    List<CtfChallengeCategoryEntity> ctfChallengeCategoryEntityList = challengeAdminDto.getCategories()
         .stream()
         .map(CtfChallengeCategoryDto::toEntity).toList();
 
     for (CtfChallengeCategoryEntity ctfChallengeCategory : ctfChallengeCategoryEntityList) {
-      CtfChallengeHasCtfChallengeCategoryEntity save = ctfChallengeHasCtfChallengeCategoryRepository.save(
-          CtfChallengeHasCtfChallengeCategoryEntity.builder()
+      challenge.addCtfChallengeHasCtfChallengeCategory(ctfChallengeHasCtfChallengeCategoryRepository
+          .save(CtfChallengeHasCtfChallengeCategoryEntity
+              .builder()
               .challenge(challenge)
               .category(ctfChallengeCategory)
-              .build());
-      challenge.getCtfChallengeHasCtfChallengeCategoryList().add(save);
+              .build()));
     }
   }
 

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -32,12 +32,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.List;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfContestAdminDto;
 import keeper.project.homepage.ctf.dto.CtfDynamicChallengeInfoDto;
 import keeper.project.homepage.ctf.dto.CtfProbMakerDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -267,8 +270,16 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("출제자 권한으로 문제 생성 - 성공")
   public void createProblemSuccess() throws Exception {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(DYNAMIC.getId()));
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
@@ -301,7 +312,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.title").value(title))
         .andExpect(jsonPath("$.data.content").value(content))
         .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-        .andExpect(jsonPath("$.data.category.id").value(category.getId()))
+        .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
+        .andExpect(jsonPath("$.data.category[1].id").value(category.get(1).getId()))
         .andExpect(jsonPath("$.data.type.id").value(type.getId()))
         .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
         .andExpect(jsonPath("$.data.creatorName").value(creator.getNickName()))
@@ -314,7 +326,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                 fieldWithPath("title").description("문제 제목"),
                 fieldWithPath("content").description("문제 내용"),
                 fieldWithPath("contestId").description("문제가 등록 될 CTF id"),
-                fieldWithPath("category.id").description("문제 카테고리 Id"),
+                fieldWithPath("category[].id").description("문제 카테고리 Id"),
                 fieldWithPath("type.id").description("문제 Type Id"),
                 fieldWithPath("isSolvable").description("현재 풀 수 있는 지 여부"),
                 fieldWithPath("score").description(
@@ -343,8 +355,13 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("회장 권한으로 STANDARD 문제 생성 - 성공")
   public void createStandardProblemSuccess() throws Exception {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
+
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
+
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
@@ -366,7 +383,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.title").value(title))
         .andExpect(jsonPath("$.data.content").value(content))
         .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-        .andExpect(jsonPath("$.data.category.id").value(category.getId()))
+        .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
         .andExpect(jsonPath("$.data.type.id").value(type.getId()))
         .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
         .andExpect(jsonPath("$.data.creatorName").value(adminEntity.getNickName()))
@@ -377,8 +394,12 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 생성 시 maxSubmitCount를 넣지 않을 경우 default value가 들어가야 한다.")
   public void createProblem_maxSubmitCount_defaultValue() throws Exception {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
+
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
@@ -401,7 +422,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.title").value(title))
         .andExpect(jsonPath("$.data.content").value(content))
         .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-        .andExpect(jsonPath("$.data.category.id").value(category.getId()))
+        .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
         .andExpect(jsonPath("$.data.type.id").value(type.getId()))
         .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
         .andExpect(jsonPath("$.data.creatorName").value(adminEntity.getNickName()))
@@ -423,8 +444,14 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @ValueSource(longs = {-10, 0, 1, 3, 15, 45, 50, 51, 123, Integer.MAX_VALUE})
   @DisplayName("회장 권한으로 STANDARD 문제 생성 - 성공")
   public void createProblem_maxSubmitCount_validValue(long maxSubmitCount) throws Exception {
-    CtfChallengeCategoryDto category = CtfChallengeCategoryDto.toDto(
-        ctfChallengeCategoryRepository.getById(FORENSIC.getId()));
+
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
+
+
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
@@ -447,7 +474,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
           .andExpect(jsonPath("$.data.title").value(title))
           .andExpect(jsonPath("$.data.content").value(content))
           .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-          .andExpect(jsonPath("$.data.category.id").value(category.getId()))
+          .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
           .andExpect(jsonPath("$.data.type.id").value(type.getId()))
           .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
           .andExpect(jsonPath("$.data.creatorName").value(adminEntity.getNickName()))
@@ -463,14 +490,14 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   }
 
   private CtfChallengeAdminDto generateCtfChallengeAdminDto(Long maxSubmitCount,
-      CtfChallengeCategoryDto category, CtfChallengeTypeDto type, MemberEntity creator,
+      List<CtfChallengeCategoryDto> category, CtfChallengeTypeDto type, MemberEntity creator,
       String title, String content, Boolean isSolvable, Long score, String flag) {
     return generateCtfChallengeAdminDto(
         maxSubmitCount, category, type, creator, title, content, isSolvable, score, flag, null);
   }
 
   private CtfChallengeAdminDto generateCtfChallengeAdminDto(Long maxSubmitCount,
-      CtfChallengeCategoryDto category, CtfChallengeTypeDto type, MemberEntity creator,
+      List<CtfChallengeCategoryDto> category, CtfChallengeTypeDto type, MemberEntity creator,
       String title, String content, Boolean isSolvable, Long score, String flag,
       CtfDynamicChallengeInfoDto dynamicInfo) {
     CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
@@ -495,8 +522,13 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png",
         "<<png data>>".getBytes());
     Long score = 1234L;
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, DYNAMIC, FORENSIC, score, true);
+        contestEntity, DYNAMIC, category, score, true);
     mockMvc.perform(multipart("/v1/admin/ctf/prob/file")
             .file(file)
             .param("challengeId", String.valueOf(challenge.getId()))
@@ -523,13 +555,17 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 오픈 - 성공")
   public void openProblemSuccess() throws Exception {
-
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, MISC, score, false);
+        contestEntity, STANDARD, category, score, false);
     generateCtfFlag(team, challenge, false);
 
     mockMvc.perform(patch("/v1/admin/ctf/prob/{pid}/open", challenge.getId())
@@ -557,13 +593,17 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 닫기 - 성공")
   public void closeProblemSuccess() throws Exception {
-
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, MISC, score, false);
+        contestEntity, STANDARD, category, score, false);
     generateCtfFlag(team, challenge, false);
 
     mockMvc.perform(patch("/v1/admin/ctf/prob/{pid}/close", challenge.getId())
@@ -596,7 +636,12 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, MISC, score, true);
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, category, score, true);
     generateCtfFlag(team, challenge, false);
 
     // when
@@ -634,8 +679,15 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
+
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, MISC, score, true);
+        contestEntity, STANDARD, category, score, true);
     CtfFlagEntity flag = generateCtfFlag(team, challenge, false);
 
     // when
@@ -672,8 +724,15 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
+
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+
     CtfChallengeEntity challenge = generateCtfChallenge(contestEntity,
-        DYNAMIC, MISC, score, true);
+        DYNAMIC, category, score, true);
     Long maxScore = 2000L;
     Long minScore = 100L;
     generateDynamicChallengeInfo(challenge, maxScore, minScore);
@@ -736,10 +795,23 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
+
+    List<CtfChallengeCategoryDto> category1 = new ArrayList<>();
+    category1.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, MISC, score, false);
+        contestEntity, STANDARD, category1, score, false);
+
+    List<CtfChallengeCategoryDto> category2 = new ArrayList<>();
+    category2.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     CtfChallengeEntity challenge2 = generateCtfChallenge(
-        contestEntity, DYNAMIC, FORENSIC, score, false);
+        contestEntity, DYNAMIC, category2, score, false);
     generateDynamicChallengeInfo(challenge2, 1000L, 100L);
     generateCtfFlag(team, challenge2, false);
     generateCtfFlag(team, challenge, false);
@@ -783,10 +855,22 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
+    List<CtfChallengeCategoryDto> category1 = new ArrayList<>();
+    category1.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, MISC, score, false);
+        contestEntity, STANDARD, category1, score, false);
+
+    List<CtfChallengeCategoryDto> category2 = new ArrayList<>();
+    category2.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     CtfChallengeEntity challenge2 = generateCtfChallenge(
-        contestEntity, DYNAMIC, FORENSIC, score, false);
+        contestEntity, DYNAMIC, category2, score, false);
     generateDynamicChallengeInfo(challenge2, 1000L, 100L);
     generateCtfFlag(team, challenge2, false);
     generateCtfFlag(team, challenge, false);

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfAdminControllerTest.java
@@ -40,7 +40,7 @@ import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfContestAdminDto;
 import keeper.project.homepage.ctf.dto.CtfDynamicChallengeInfoDto;
 import keeper.project.homepage.ctf.dto.CtfProbMakerDto;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -270,15 +270,9 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("출제자 권한으로 문제 생성 - 성공")
   public void createProblemSuccess() throws Exception {
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
+    categories.add(MISC);
 
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(DYNAMIC.getId()));
@@ -299,7 +293,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long score = 1234L;
     String flag = "flag{keeper}";
     CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(35L,
-        category, type, creator, title, content, isSolvable, score, flag, dynamicInfo);
+        categories, type, creator, title, content, isSolvable, score, flag, dynamicInfo);
 
     mockMvc.perform(post("/v1/admin/ctf/prob")
             .header("Authorization", creatorToken)
@@ -312,8 +306,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.title").value(title))
         .andExpect(jsonPath("$.data.content").value(content))
         .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-        .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
-        .andExpect(jsonPath("$.data.category[1].id").value(category.get(1).getId()))
+        .andExpect(jsonPath("$.data.categories[0].id").value(categories.get(0).getId()))
+        .andExpect(jsonPath("$.data.categories[1].id").value(categories.get(1).getId()))
         .andExpect(jsonPath("$.data.type.id").value(type.getId()))
         .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
         .andExpect(jsonPath("$.data.creatorName").value(creator.getNickName()))
@@ -326,7 +320,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
                 fieldWithPath("title").description("문제 제목"),
                 fieldWithPath("content").description("문제 내용"),
                 fieldWithPath("contestId").description("문제가 등록 될 CTF id"),
-                fieldWithPath("category[].id").description("문제 카테고리 Id"),
+                fieldWithPath("categories[].id").description("문제 카테고리 Id"),
                 fieldWithPath("type.id").description("문제 Type Id"),
                 fieldWithPath("isSolvable").description("현재 풀 수 있는 지 여부"),
                 fieldWithPath("score").description(
@@ -356,11 +350,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("회장 권한으로 STANDARD 문제 생성 - 성공")
   public void createStandardProblemSuccess() throws Exception {
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
 
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
@@ -374,7 +365,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long score = 1234L;
     String flag = "flag{keeper}";
     CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(35L,
-        category, type, creator, title, content, isSolvable, score, flag);
+        categories, type, creator, title, content, isSolvable, score, flag);
 
     createChallengeControllerTest(challenge)
         .andExpect(status().isOk())
@@ -383,7 +374,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.title").value(title))
         .andExpect(jsonPath("$.data.content").value(content))
         .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-        .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
+        .andExpect(jsonPath("$.data.categories[0].id").value(categories.get(0).getId()))
         .andExpect(jsonPath("$.data.type.id").value(type.getId()))
         .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
         .andExpect(jsonPath("$.data.creatorName").value(adminEntity.getNickName()))
@@ -394,11 +385,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 생성 시 maxSubmitCount를 넣지 않을 경우 default value가 들어가야 한다.")
   public void createProblem_maxSubmitCount_defaultValue() throws Exception {
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
 
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
@@ -413,7 +401,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     String flag = "flag{keeper}";
 
     CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(
-        null, category, type, creator, title, content, isSolvable, score, flag);
+        null, categories, type, creator, title, content, isSolvable, score, flag);
 
     createChallengeControllerTest(challenge)
         .andExpect(status().isOk())
@@ -422,7 +410,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.title").value(title))
         .andExpect(jsonPath("$.data.content").value(content))
         .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-        .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
+        .andExpect(jsonPath("$.data.categories[0].id").value(categories.get(0).getId()))
         .andExpect(jsonPath("$.data.type.id").value(type.getId()))
         .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
         .andExpect(jsonPath("$.data.creatorName").value(adminEntity.getNickName()))
@@ -445,12 +433,8 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @DisplayName("회장 권한으로 STANDARD 문제 생성 - 성공")
   public void createProblem_maxSubmitCount_validValue(long maxSubmitCount) throws Exception {
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
-
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
 
     CtfChallengeTypeDto type = CtfChallengeTypeDto.toDto(
         ctfChallengeTypeRepository.getById(STANDARD.getId()));
@@ -464,7 +448,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long score = 1234L;
     String flag = "flag{keeper}";
     CtfChallengeAdminDto challenge = generateCtfChallengeAdminDto(
-        maxSubmitCount, category, type, creator, title, content, isSolvable, score, flag);
+        maxSubmitCount, categories, type, creator, title, content, isSolvable, score, flag);
 
     if (MIN_SUBMIT_COUNT <= maxSubmitCount && maxSubmitCount <= MAX_SUBMIT_COUNT) {
       createChallengeControllerTest(challenge)
@@ -474,7 +458,7 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
           .andExpect(jsonPath("$.data.title").value(title))
           .andExpect(jsonPath("$.data.content").value(content))
           .andExpect(jsonPath("$.data.contestId").value(contestEntity.getId()))
-          .andExpect(jsonPath("$.data.category[0].id").value(category.get(0).getId()))
+          .andExpect(jsonPath("$.data.categories[0].id").value(categories.get(0).getId()))
           .andExpect(jsonPath("$.data.type.id").value(type.getId()))
           .andExpect(jsonPath("$.data.isSolvable").value(isSolvable))
           .andExpect(jsonPath("$.data.creatorName").value(adminEntity.getNickName()))
@@ -490,21 +474,30 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   }
 
   private CtfChallengeAdminDto generateCtfChallengeAdminDto(Long maxSubmitCount,
-      List<CtfChallengeCategoryDto> category, CtfChallengeTypeDto type, MemberEntity creator,
+      List<CtfChallengeCategory> categories, CtfChallengeTypeDto type, MemberEntity creator,
       String title, String content, Boolean isSolvable, Long score, String flag) {
     return generateCtfChallengeAdminDto(
-        maxSubmitCount, category, type, creator, title, content, isSolvable, score, flag, null);
+        maxSubmitCount, categories, type, creator, title, content, isSolvable, score, flag, null);
   }
 
   private CtfChallengeAdminDto generateCtfChallengeAdminDto(Long maxSubmitCount,
-      List<CtfChallengeCategoryDto> category, CtfChallengeTypeDto type, MemberEntity creator,
+      List<CtfChallengeCategory> categories, CtfChallengeTypeDto type, MemberEntity creator,
       String title, String content, Boolean isSolvable, Long score, String flag,
       CtfDynamicChallengeInfoDto dynamicInfo) {
+
+    List<CtfChallengeCategoryDto> categoryDtos = categories
+        .stream()
+        .map(ctfChallengeCategory -> CtfChallengeCategoryDto
+            .builder()
+            .id(ctfChallengeCategory.getId())
+            .name(ctfChallengeCategory.getName()).build())
+        .toList();
+
     CtfChallengeAdminDto challenge = CtfChallengeAdminDto.builder()
         .title(title)
         .content(content)
         .contestId(contestEntity.getId())
-        .category(category)
+        .categories(categoryDtos)
         .type(type)
         .isSolvable(isSolvable)
         .creatorName(creator.getNickName())
@@ -522,13 +515,12 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png",
         "<<png data>>".getBytes());
     Long score = 1234L;
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
+
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, DYNAMIC, category, score, true);
+        contestEntity, DYNAMIC, categories, score, true);
     mockMvc.perform(multipart("/v1/admin/ctf/prob/file")
             .file(file)
             .param("challengeId", String.valueOf(challenge.getId()))
@@ -555,17 +547,14 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
   @Test
   @DisplayName("문제 오픈 - 성공")
   public void openProblemSuccess() throws Exception {
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
     MemberEntity creator = generateMemberEntity(출제자, 정회원, 일반회원);
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, category, score, false);
+        contestEntity, STANDARD, categories, score, false);
     generateCtfFlag(team, challenge, false);
 
     mockMvc.perform(patch("/v1/admin/ctf/prob/{pid}/open", challenge.getId())
@@ -597,13 +586,10 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, category, score, false);
+        contestEntity, STANDARD, categories, score, false);
     generateCtfFlag(team, challenge, false);
 
     mockMvc.perform(patch("/v1/admin/ctf/prob/{pid}/close", challenge.getId())
@@ -636,12 +622,9 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, category, score, true);
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
+    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, categories, score, true);
     generateCtfFlag(team, challenge, false);
 
     // when
@@ -680,14 +663,11 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
 
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, category, score, true);
+        contestEntity, STANDARD, categories, score, true);
     CtfFlagEntity flag = generateCtfFlag(team, challenge, false);
 
     // when
@@ -725,14 +705,11 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
 
     CtfChallengeEntity challenge = generateCtfChallenge(contestEntity,
-        DYNAMIC, category, score, true);
+        DYNAMIC, categories, score, true);
     Long maxScore = 2000L;
     Long minScore = 100L;
     generateDynamicChallengeInfo(challenge, maxScore, minScore);
@@ -796,32 +773,27 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
 
-    List<CtfChallengeCategoryDto> category1 = new ArrayList<>();
-    category1.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories1 = new ArrayList<>();
+    categories1.add(MISC);
 
-    CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, category1, score, false);
+    CtfChallengeEntity challenge1 = generateCtfChallenge(
+        contestEntity, STANDARD, categories1, score, false);
 
-    List<CtfChallengeCategoryDto> category2 = new ArrayList<>();
-    category2.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories2 = new ArrayList<>();
+    categories2.add(FORENSIC);
+
     CtfChallengeEntity challenge2 = generateCtfChallenge(
-        contestEntity, DYNAMIC, category2, score, false);
+        contestEntity, DYNAMIC, categories2, score, false);
     generateDynamicChallengeInfo(challenge2, 1000L, 100L);
     generateCtfFlag(team, challenge2, false);
-    generateCtfFlag(team, challenge, false);
+    generateCtfFlag(team, challenge1, false);
 
     // when
     MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png",
         "<<png data>>".getBytes());
     mockMvc.perform(multipart("/v1/admin/ctf/prob/file")
         .file(file)
-        .param("challengeId", String.valueOf(challenge.getId()))
+        .param("challengeId", String.valueOf(challenge1.getId()))
         .param("page", "0")
         .param("size", "10")
         .header("Authorization", adminToken)
@@ -855,22 +827,16 @@ class CtfAdminControllerTest extends CtfSpringTestHelper {
     Long teamScore = 0L;
     Long score = 1234L;
     CtfTeamEntity team = generateCtfTeam(contestEntity, creator, teamScore);
-    List<CtfChallengeCategoryDto> category1 = new ArrayList<>();
-    category1.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories1 = new ArrayList<>();
+    categories1.add(MISC);
 
     CtfChallengeEntity challenge = generateCtfChallenge(
-        contestEntity, STANDARD, category1, score, false);
+        contestEntity, STANDARD, categories1, score, false);
 
-    List<CtfChallengeCategoryDto> category2 = new ArrayList<>();
-    category2.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories2 = new ArrayList<>();
+    categories2.add(FORENSIC);
     CtfChallengeEntity challenge2 = generateCtfChallenge(
-        contestEntity, DYNAMIC, category2, score, false);
+        contestEntity, DYNAMIC, categories2, score, false);
     generateDynamicChallengeInfo(challenge2, 1000L, 100L);
     generateCtfFlag(team, challenge2, false);
     generateCtfFlag(team, challenge, false);

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfChallengeControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfChallengeControllerTest.java
@@ -19,6 +19,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -54,13 +58,17 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     CtfContestEntity contest = generateCtfContest(adminEntity, true);
 
     Long score = 1000L;
-
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, FORENSIC, score, true);
+        contest, DYNAMIC, category, score, true);
     CtfChallengeEntity standardChallenge = generateCtfChallenge(
-        contest, STANDARD, MISC, score, true);
+        contest, STANDARD, category, score, true);
     CtfChallengeEntity notSolvable = generateCtfChallenge(
-        contest, DYNAMIC, WEB, score, false);
+        contest, DYNAMIC, category, score, false);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
 
@@ -79,8 +87,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.list[0].content").doesNotExist())
         .andExpect(jsonPath("$.list[0].contestId")
             .value(dynamicChallenge.getCtfContestEntity().getId()))
-        .andExpect(jsonPath("$.list[0].category.id")
-            .value(dynamicChallenge.getCtfChallengeCategoryEntity().getId()))
+        .andExpect(jsonPath("$.list[0].category[0].id")
+            .value(category.get(0).getId()))
         .andExpect(jsonPath("$.list[0].type.id").doesNotExist())
         .andExpect(jsonPath("$.list[0].isSolvable").doesNotExist())
         .andExpect(jsonPath("$.list[0].score").value(dynamicChallenge.getScore()))
@@ -91,8 +99,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.list[1].content").doesNotExist())
         .andExpect(jsonPath("$.list[1].contestId")
             .value(standardChallenge.getCtfContestEntity().getId()))
-        .andExpect(jsonPath("$.list[1].category.id")
-            .value(standardChallenge.getCtfChallengeCategoryEntity().getId()))
+        .andExpect(jsonPath("$.list[1].category[0].id")
+            .value(category.get(0).getId()))
         .andExpect(jsonPath("$.list[1].type.id").doesNotExist())
         .andExpect(jsonPath("$.list[1].isSolvable").doesNotExist())
         .andExpect(jsonPath("$.list[1].score").value(standardChallenge.getScore()))
@@ -116,11 +124,17 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     CtfContestEntity contest = generateCtfContest(adminEntity, true);
 
     Long score = 1000L;
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
 
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, FORENSIC, score, true);
+        contest, DYNAMIC, category, score, true);
     CtfChallengeEntity standardChallenge = generateCtfChallenge(
-        contest, STANDARD, MISC, score, true);
+        contest, STANDARD, category, score, true);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
 
@@ -148,8 +162,14 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     Long maxScore = 1234L;
     Long minScore = 567L;
 
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
+
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, FORENSIC, score, true);
+        contest, DYNAMIC, category, score, true);
     generateDynamicChallengeInfo(dynamicChallenge, maxScore, minScore);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
@@ -193,9 +213,13 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     Long score = 1000L;
     Long maxScore = 1234L;
     Long minScore = 567L;
-
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, FORENSIC, score, true);
+        contest, DYNAMIC, category, score, true);
     generateDynamicChallengeInfo(dynamicChallenge, maxScore, minScore);
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
     CtfFlagEntity flag = generateCtfFlag(team, dynamicChallenge, false, 0L);
@@ -220,9 +244,13 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     CtfContestEntity contest = generateCtfContest(adminEntity, true);
 
     Long score = 1000L;
-
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, FORENSIC, score, true);
+        contest, DYNAMIC, category, score, true);
     generateFileInChallenge(dynamicChallenge);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
@@ -239,8 +267,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.content").value(dynamicChallenge.getDescription()))
         .andExpect(jsonPath("$.data.contestId")
             .value(dynamicChallenge.getCtfContestEntity().getId()))
-        .andExpect(jsonPath("$.data.category.id")
-            .value(dynamicChallenge.getCtfChallengeCategoryEntity().getId()))
+        .andExpect(jsonPath("$.data.category[0].id")
+            .value(category.get(0).getId()))
         .andExpect(jsonPath("$.data.type.id").doesNotExist())
         .andExpect(jsonPath("$.data.isSolvable").doesNotExist())
         .andExpect(

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfChallengeControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfChallengeControllerTest.java
@@ -21,8 +21,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -58,17 +58,14 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     CtfContestEntity contest = generateCtfContest(adminEntity, true);
 
     Long score = 1000L;
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, category, score, true);
+        contest, DYNAMIC, categories, score, true);
     CtfChallengeEntity standardChallenge = generateCtfChallenge(
-        contest, STANDARD, category, score, true);
+        contest, STANDARD, categories, score, true);
     CtfChallengeEntity notSolvable = generateCtfChallenge(
-        contest, DYNAMIC, category, score, false);
+        contest, DYNAMIC, categories, score, false);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
 
@@ -87,8 +84,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.list[0].content").doesNotExist())
         .andExpect(jsonPath("$.list[0].contestId")
             .value(dynamicChallenge.getCtfContestEntity().getId()))
-        .andExpect(jsonPath("$.list[0].category[0].id")
-            .value(category.get(0).getId()))
+        .andExpect(jsonPath("$.list[0].categories[0].id")
+            .value(categories.get(0).getId()))
         .andExpect(jsonPath("$.list[0].type.id").doesNotExist())
         .andExpect(jsonPath("$.list[0].isSolvable").doesNotExist())
         .andExpect(jsonPath("$.list[0].score").value(dynamicChallenge.getScore()))
@@ -99,8 +96,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.list[1].content").doesNotExist())
         .andExpect(jsonPath("$.list[1].contestId")
             .value(standardChallenge.getCtfContestEntity().getId()))
-        .andExpect(jsonPath("$.list[1].category[0].id")
-            .value(category.get(0).getId()))
+        .andExpect(jsonPath("$.list[1].categories[0].id")
+            .value(categories.get(0).getId()))
         .andExpect(jsonPath("$.list[1].type.id").doesNotExist())
         .andExpect(jsonPath("$.list[1].isSolvable").doesNotExist())
         .andExpect(jsonPath("$.list[1].score").value(standardChallenge.getScore()))
@@ -124,17 +121,14 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     CtfContestEntity contest = generateCtfContest(adminEntity, true);
 
     Long score = 1000L;
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    List<CtfChallengeCategory> categories = new ArrayList<>();
 
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    categories.add(FORENSIC);
 
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, category, score, true);
+        contest, DYNAMIC, categories, score, true);
     CtfChallengeEntity standardChallenge = generateCtfChallenge(
-        contest, STANDARD, category, score, true);
+        contest, STANDARD, categories, score, true);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
 
@@ -162,14 +156,11 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     Long maxScore = 1234L;
     Long minScore = 567L;
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
 
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, category, score, true);
+        contest, DYNAMIC, categories, score, true);
     generateDynamicChallengeInfo(dynamicChallenge, maxScore, minScore);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
@@ -213,13 +204,10 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     Long score = 1000L;
     Long maxScore = 1234L;
     Long minScore = 567L;
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, category, score, true);
+        contest, DYNAMIC, categories, score, true);
     generateDynamicChallengeInfo(dynamicChallenge, maxScore, minScore);
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
     CtfFlagEntity flag = generateCtfFlag(team, dynamicChallenge, false, 0L);
@@ -244,13 +232,10 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
     CtfContestEntity contest = generateCtfContest(adminEntity, true);
 
     Long score = 1000L;
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
     CtfChallengeEntity dynamicChallenge = generateCtfChallenge(
-        contest, DYNAMIC, category, score, true);
+        contest, DYNAMIC, categories, score, true);
     generateFileInChallenge(dynamicChallenge);
 
     CtfTeamEntity team = generateCtfTeam(contest, userEntity, 0L);
@@ -267,8 +252,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.data.content").value(dynamicChallenge.getDescription()))
         .andExpect(jsonPath("$.data.contestId")
             .value(dynamicChallenge.getCtfContestEntity().getId()))
-        .andExpect(jsonPath("$.data.category[0].id")
-            .value(category.get(0).getId()))
+        .andExpect(jsonPath("$.data.categories[0].id")
+            .value(categories.get(0).getId()))
         .andExpect(jsonPath("$.data.type.id").doesNotExist())
         .andExpect(jsonPath("$.data.isSolvable").doesNotExist())
         .andExpect(

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfSpringTestHelper.java
@@ -11,8 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import keeper.project.homepage.ApiControllerTestHelper;
-import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeHasCtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity;
@@ -188,7 +188,7 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
   protected CtfChallengeEntity generateCtfChallenge(
       CtfContestEntity ctfContestEntity,
       CtfChallengeType ctfChallengeType,
-      List<CtfChallengeCategoryDto> category,
+      List<CtfChallengeCategory> category,
       Long score,
       boolean isSolvable) {
     final long epochTime = System.nanoTime();
@@ -210,8 +210,14 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         .build();
     ctfChallengeRepository.save(entity);
 
-    List<CtfChallengeCategoryEntity> ctfChallengeCategoryEntityList = category.stream()
-        .map(CtfChallengeCategoryDto::toEntity).toList();
+    List<CtfChallengeCategoryEntity> ctfChallengeCategoryEntityList = category
+        .stream()
+        .map(ctfChallengeCategory -> CtfChallengeCategoryEntity
+            .builder()
+            .id(ctfChallengeCategory.getId())
+            .name(ctfChallengeCategory.getName())
+            .build())
+        .toList();
 
     for (CtfChallengeCategoryEntity ctfChallengeCategory : ctfChallengeCategoryEntityList) {
       CtfChallengeHasCtfChallengeCategoryEntity save = ctfChallengeHasCtfChallengeCategoryRepository.save(
@@ -302,8 +308,8 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
     commonFields.addAll(Arrays.asList(
         fieldWithPath(prefix + ".challengeId").description("해당 문제의 Id"),
         fieldWithPath(prefix + ".title").description("문제 제목"),
-        fieldWithPath(prefix + ".category[].id").description("문제가 속한 카테고리의 id"),
-        fieldWithPath(prefix + ".category[].name").description("문제가 속한 카테고리의 이름"),
+        fieldWithPath(prefix + ".categories[].id").description("문제가 속한 카테고리의 id"),
+        fieldWithPath(prefix + ".categories[].name").description("문제가 속한 카테고리의 이름"),
         fieldWithPath(prefix + ".score").description("문제의 점수"),
         fieldWithPath(prefix + ".isSolved").description("내가 풀었는 지"),
         fieldWithPath(prefix + ".maxSubmitCount").description("최대 제출 횟수"),
@@ -333,8 +339,8 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".challengeId").description("해당 문제의 Id"),
         fieldWithPath(prefix + ".title").description("문제 제목"),
         fieldWithPath(prefix + ".content").description("문제 설명"),
-        fieldWithPath(prefix + ".category[].id").description("문제가 속한 카테고리의 id"),
-        fieldWithPath(prefix + ".category[].name").description("문제가 속한 카테고리의 이름"),
+        fieldWithPath(prefix + ".categories[].id").description("문제가 속한 카테고리의 id"),
+        fieldWithPath(prefix + ".categories[].name").description("문제가 속한 카테고리의 이름"),
         fieldWithPath(prefix + ".type.id").description("문제가 속한 타입의 id"),
         fieldWithPath(prefix + ".type.name").description("문제가 속한 타입의 이름"),
         fieldWithPath(prefix + ".flag").description("문제에 설정 된 flag (현재는 모든 팀이 동일한 flag를 가집니다."),
@@ -388,8 +394,8 @@ public class CtfSpringTestHelper extends ApiControllerTestHelper {
         fieldWithPath(prefix + ".challengeId").description("해당 문제의 Id"),
         fieldWithPath(prefix + ".title").description("문제 제목"),
         fieldWithPath(prefix + ".content").description("문제 설명"),
-        fieldWithPath(prefix + ".category[].id").description("문제가 속한 카테고리의 id"),
-        fieldWithPath(prefix + ".category[].name").description("문제가 속한 카테고리의 이름"),
+        fieldWithPath(prefix + ".categories[].id").description("문제가 속한 카테고리의 id"),
+        fieldWithPath(prefix + ".categories[].name").description("문제가 속한 카테고리의 이름"),
         fieldWithPath(prefix + ".score").description("문제의 점수"),
         fieldWithPath(prefix + ".creatorName").description("문제 생성자 이름"),
         fieldWithPath(prefix + ".contestId").description("문제의 대회 Id"),

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfTeamControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfTeamControllerTest.java
@@ -1,5 +1,6 @@
 package keeper.project.homepage.ctf.controller;
 
+import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.FORENSIC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -17,7 +18,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.List;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfTeamEntity;
@@ -189,8 +194,12 @@ class CtfTeamControllerTest extends CtfSpringTestHelper {
         .build();
     ctfTeamHasMemberRepository.save(teamHasMemberEntity);
     team.getCtfTeamHasMemberEntityList().add(teamHasMemberEntity);
-
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, MISC, 1234L,
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, category, 1234L,
         false);
     generateCtfFlag(team, challenge, true);
 

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfTeamControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfTeamControllerTest.java
@@ -20,9 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.ArrayList;
 import java.util.List;
-import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
-import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfTeamEntity;
@@ -194,12 +192,9 @@ class CtfTeamControllerTest extends CtfSpringTestHelper {
         .build();
     ctfTeamHasMemberRepository.save(teamHasMemberEntity);
     team.getCtfTeamHasMemberEntityList().add(teamHasMemberEntity);
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
-    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, category, 1234L,
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
+    CtfChallengeEntity challenge = generateCtfChallenge(contestEntity, STANDARD, categories, 1234L,
         false);
     generateCtfFlag(team, challenge, true);
 

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfChallengeRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfChallengeRepositoryTest.java
@@ -27,8 +27,6 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
     boolean isSolvable = true;
     CtfChallengeTypeEntity ctfChallengeTypeEntity = ctfChallengeTypeRepository.getById(
         STANDARD.getId());
-    CtfChallengeCategoryEntity ctfChallengeCategoryEntity = ctfChallengeCategoryRepository.getById(
-        SYSTEM.getId());
     Long score = 1000L;
     CtfContestEntity contest = generateCtfContest(member);
 
@@ -40,7 +38,7 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
         .creator(member) // Virtual Member
         .isSolvable(isSolvable)
         .ctfChallengeTypeEntity(ctfChallengeTypeEntity)
-        .ctfChallengeCategoryEntity(ctfChallengeCategoryEntity)
+        .ctfChallengeHasCtfChallengeCategoryList(new ArrayList<>())
         .score(score)
         .ctfContestEntity(contest)
         .ctfFlagEntity(new ArrayList<>())
@@ -55,7 +53,6 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
     assertThat(findChallenge.getCreator()).isEqualTo(member);
     assertThat(findChallenge.getIsSolvable()).isEqualTo(isSolvable);
     assertThat(findChallenge.getCtfChallengeTypeEntity()).isEqualTo(ctfChallengeTypeEntity);
-    assertThat(findChallenge.getCtfChallengeCategoryEntity()).isEqualTo(ctfChallengeCategoryEntity);
     assertThat(findChallenge.getScore()).isEqualTo(score);
     assertThat(findChallenge.getCtfContestEntity()).isEqualTo(contest);
   }
@@ -71,8 +68,6 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
     boolean isSolvable = true;
     CtfChallengeTypeEntity ctfChallengeTypeEntity = ctfChallengeTypeRepository.getById(
         STANDARD.getId());
-    CtfChallengeCategoryEntity ctfChallengeCategoryEntity = ctfChallengeCategoryRepository.getById(
-        SYSTEM.getId());
     Long score = 1000L;
     CtfContestEntity contest = generateCtfContest(member);
 
@@ -84,7 +79,7 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
         .creator(member) // Virtual Member
         .isSolvable(isSolvable)
         .ctfChallengeTypeEntity(ctfChallengeTypeEntity)
-        .ctfChallengeCategoryEntity(ctfChallengeCategoryEntity)
+        .ctfChallengeHasCtfChallengeCategoryList(new ArrayList<>())
         .score(score)
         .ctfContestEntity(contest)
         .ctfFlagEntity(new ArrayList<>())
@@ -99,7 +94,6 @@ class CtfChallengeRepositoryTest extends CtfTestHelper {
     assertThat(findChallenge.getCreator()).isEqualTo(member);
     assertThat(findChallenge.getIsSolvable()).isEqualTo(isSolvable);
     assertThat(findChallenge.getCtfChallengeTypeEntity()).isEqualTo(ctfChallengeTypeEntity);
-    assertThat(findChallenge.getCtfChallengeCategoryEntity()).isEqualTo(ctfChallengeCategoryEntity);
     assertThat(findChallenge.getScore()).isEqualTo(score);
     assertThat(findChallenge.getCtfContestEntity()).isEqualTo(contest);
   }

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfFlagRepositoryTest.java
@@ -6,7 +6,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeHasCtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.ctf.entity.CtfTeamEntity;
@@ -30,7 +35,8 @@ class CtfFlagRepositoryTest extends CtfTestHelper {
     MemberEntity member = memberRepository.getById(1L);
     CtfContestEntity contest = generateCtfContest(member);
     CtfTeamEntity ctfTeam = generateCtfTeam(contest, member, 0L);
-    CtfChallengeEntity ctfChallenge = generateCtfChallenge(contest, STANDARD, MISC, 1000L);
+
+    CtfChallengeEntity ctfChallenge = generateCtfChallenge(contest, STANDARD, 1000L);
     return CtfFlagEntity.builder()
         .content(content)
         .ctfTeamEntity(ctfTeam)

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfSubmitLogRepositoryTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfSubmitLogRepositoryTest.java
@@ -5,6 +5,8 @@ import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChall
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
@@ -26,7 +28,8 @@ class CtfSubmitLogRepositoryTest extends CtfTestHelper {
     MemberEntity member = memberRepository.getById(1L);
     CtfContestEntity contest = generateCtfContest(member);
     CtfTeamEntity ctfTeam = generateCtfTeam(contest, member, 0L);
-    CtfChallengeEntity ctfChallenge = generateCtfChallenge(contest, STANDARD, MISC, 1000L);
+
+    CtfChallengeEntity ctfChallenge = generateCtfChallenge(contest, STANDARD, 1000L);
 
     // when
     CtfSubmitLogEntity submitLog = CtfSubmitLogEntity.builder()

--- a/src/test/java/keeper/project/homepage/ctf/repository/CtfTestHelper.java
+++ b/src/test/java/keeper/project/homepage/ctf/repository/CtfTestHelper.java
@@ -3,6 +3,8 @@ package keeper.project.homepage.ctf.repository;
 import static java.time.LocalDateTime.now;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
@@ -111,13 +113,12 @@ public class CtfTestHelper {
   protected CtfChallengeEntity generateCtfChallenge(
       CtfContestEntity ctfContestEntity,
       CtfChallengeType ctfChallengeType,
-      CtfChallengeCategory ctfChallengeCategory,
       Long score) {
     final long epochTime = System.nanoTime();
     CtfChallengeTypeEntity ctfChallengeTypeEntity = ctfChallengeTypeRepository.getById(
         ctfChallengeType.getId());
-    CtfChallengeCategoryEntity ctfChallengeCategoryEntity = ctfChallengeCategoryRepository.getById(
-        ctfChallengeCategory.getId());
+
+
     CtfChallengeEntity entity = CtfChallengeEntity.builder()
         .name("name_" + epochTime)
         .description("desc_" + epochTime)
@@ -125,11 +126,12 @@ public class CtfTestHelper {
         .creator(memberRepository.getById(1L)) // Virtual Member
         .isSolvable(false)
         .ctfChallengeTypeEntity(ctfChallengeTypeEntity)
-        .ctfChallengeCategoryEntity(ctfChallengeCategoryEntity)
+        .ctfChallengeHasCtfChallengeCategoryList(new ArrayList<>())
         .score(score)
         .ctfContestEntity(ctfContestEntity)
         .maxSubmitCount(123L)
         .build();
+
     ctfChallengeRepository.save(entity);
     return entity;
   }

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfAdminServiceTest.java
@@ -75,7 +75,8 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
         .id(WEB.getId())
         .name(WEB.getName())
         .build()));
-    CtfChallengeAdminDto result = createStandardChallenge(1234L, "flag", "content", "title", category, 123L);
+    CtfChallengeAdminDto result = createStandardChallenge(1234L, "flag", "content", "title",
+        category, 123L);
     CtfFlagEntity flag = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
         result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
 
@@ -87,7 +88,6 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     assertThat(result.getContent()).isEqualTo("content");
     assertThat(result.getTitle()).isEqualTo("title");
     assertThat(result.getScore()).isEqualTo(1234L);
-    assertThat(result.getCategory().size()).isEqualTo(1);
     assertThat(result.getCategory().get(0).getId()).isEqualTo(category.get(0).getId());
     assertThat(result.getCategory().size()).isEqualTo(1);
     assertThat(result.getContestId()).isEqualTo(ctfContestEntity.getId());
@@ -107,7 +107,8 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
         .id(FORENSIC.getId())
         .name(FORENSIC.getName())
         .build()));
-    CtfChallengeAdminDto result = createStandardChallenge(1234L, "flag", "content", "title", category, 123L);
+    CtfChallengeAdminDto result = createStandardChallenge(1234L, "flag", "content", "title",
+        category, 123L);
     CtfFlagEntity flag = ctfFlagRepository.findByCtfChallengeEntityIdAndCtfTeamEntityId(
         result.getChallengeId(), CtfUtilService.VIRTUAL_TEAM_ID).orElseThrow();
 
@@ -127,8 +128,10 @@ class CtfAdminServiceTest extends CtfSpringTestHelper {
     assertThat(flag.getIsCorrect()).isEqualTo(false);
   }
 
-  private CtfChallengeAdminDto createStandardChallenge(long score, List<CtfChallengeCategoryDto> category) {
-    return createStandardChallenge(score, getRandomUUID(), getRandomUUID(), getRandomUUID(), category, 15L);
+  private CtfChallengeAdminDto createStandardChallenge(long score,
+      List<CtfChallengeCategoryDto> category) {
+    return createStandardChallenge(score, getRandomUUID(), getRandomUUID(), getRandomUUID(),
+        category, 15L);
   }
 
   private CtfChallengeAdminDto createStandardChallenge(long score, String flag, String content,

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
@@ -13,9 +13,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfFlagDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -50,7 +53,12 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
     Long score = 1000L;
     Long maxScore = 1234L;
     Long minScore = 567L;
-    dynamicChallenge = generateCtfChallenge(contest, DYNAMIC, FORENSIC, score, true);
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
+    dynamicChallenge = generateCtfChallenge(contest, DYNAMIC, category, score, true);
     generateDynamicChallengeInfo(dynamicChallenge, maxScore, minScore);
     teamEntity = generateCtfTeam(contest, userEntity, 0L);
     setAuthentication(userEntity, "ROLE_회원");

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfChallengeServiceTest.java
@@ -16,9 +16,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
-import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfFlagDto;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -53,12 +53,9 @@ class CtfChallengeServiceTest extends CtfSpringTestHelper {
     Long score = 1000L;
     Long maxScore = 1234L;
     Long minScore = 567L;
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
-    dynamicChallenge = generateCtfChallenge(contest, DYNAMIC, category, score, true);
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
+    dynamicChallenge = generateCtfChallenge(contest, DYNAMIC, categories, score, true);
     generateDynamicChallengeInfo(dynamicChallenge, maxScore, minScore);
     teamEntity = generateCtfTeam(contest, userEntity, 0L);
     setAuthentication(userEntity, "ROLE_회원");

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
@@ -4,7 +4,6 @@ import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회�
 import static keeper.project.homepage.ApiControllerTestHelper.MemberRankName.우수회원;
 import static keeper.project.homepage.ApiControllerTestHelper.MemberTypeName.정회원;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
-import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.WEB;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,7 +15,7 @@ import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfFlagDto;
 import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.ctf.entity.CtfSubmitLogEntity;
@@ -159,11 +158,12 @@ public class CtfServiceTest extends CtfSpringTestHelper {
             List.of(new SimpleGrantedAuthority("ROLE_회원"))));
     final long epochTime = System.nanoTime();
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(MISC.getId())
-        .name(MISC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(MISC);
+
+    List<CtfChallengeCategoryDto> categoryDtos = categories.stream().map(
+        ctfChallengeCategory -> CtfChallengeCategoryDto.builder().id(ctfChallengeCategory.getId())
+            .name(ctfChallengeCategory.getName()).build()).toList();
 
     CtfChallengeAdminDto createChallenge = CtfChallengeAdminDto.builder()
         .title("TITLE_" + epochTime)
@@ -175,7 +175,7 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         .type(CtfChallengeTypeDto.builder()
             .id(STANDARD.getId())
             .build())
-        .category(category)
+        .categories(categoryDtos)
         .maxSubmitCount(100L)
         .build();
     return ctfAdminService.createChallenge(createChallenge);

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfServiceTest.java
@@ -4,9 +4,11 @@ import static keeper.project.homepage.ApiControllerTestHelper.MemberJobName.회�
 import static keeper.project.homepage.ApiControllerTestHelper.MemberRankName.우수회원;
 import static keeper.project.homepage.ApiControllerTestHelper.MemberTypeName.정회원;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
+import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.WEB;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
@@ -14,6 +16,7 @@ import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfFlagDto;
 import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
 import keeper.project.homepage.ctf.entity.CtfSubmitLogEntity;
@@ -155,6 +158,13 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         new UsernamePasswordAuthenticationToken(member.getId(), member.getPassword(),
             List.of(new SimpleGrantedAuthority("ROLE_회원"))));
     final long epochTime = System.nanoTime();
+
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(MISC.getId())
+        .name(MISC.getName())
+        .build()));
+
     CtfChallengeAdminDto createChallenge = CtfChallengeAdminDto.builder()
         .title("TITLE_" + epochTime)
         .content("CONTENT_" + epochTime)
@@ -165,9 +175,7 @@ public class CtfServiceTest extends CtfSpringTestHelper {
         .type(CtfChallengeTypeDto.builder()
             .id(STANDARD.getId())
             .build())
-        .category(CtfChallengeCategoryDto.builder()
-            .id(MISC.getId())
-            .build())
+        .category(category)
         .maxSubmitCount(100L)
         .build();
     return ctfAdminService.createChallenge(createChallenge);

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
@@ -1,6 +1,5 @@
 package keeper.project.homepage.ctf.service;
 
-import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.SYSTEM;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 
@@ -12,7 +11,7 @@ import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
 import org.assertj.core.api.Assertions;
@@ -177,11 +176,16 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
     String testFlag = "testFlag";
     Long testScore = 1234L;
 
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(SYSTEM.getId())
-        .name(SYSTEM.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(SYSTEM);
+
+    List<CtfChallengeCategoryDto> categoryDtos = categories
+        .stream()
+        .map(ctfChallengeCategory -> CtfChallengeCategoryDto
+            .builder()
+            .id(ctfChallengeCategory.getId())
+            .name(ctfChallengeCategory.getName()).build())
+        .toList();
 
     CtfChallengeAdminDto createChallengeInfo = CtfChallengeAdminDto.builder()
         .content(testContent)
@@ -189,7 +193,7 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
         .flag(testFlag)
         .isSolvable(true)
         .type(CtfChallengeTypeDto.builder().id(STANDARD.getId()).build())
-        .category(category)
+        .categories(categoryDtos)
         .title(testTitle)
         .score(testScore)
         .maxSubmitCount(123L)

--- a/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/service/CtfTeamServiceTest.java
@@ -1,15 +1,18 @@
 package keeper.project.homepage.ctf.service;
 
+import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.SYSTEM;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
 import keeper.project.homepage.ctf.dto.CtfChallengeAdminDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.dto.CtfChallengeTypeDto;
 import keeper.project.homepage.ctf.dto.CtfTeamDetailDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.member.entity.MemberEntity;
 import org.assertj.core.api.Assertions;
@@ -174,14 +177,19 @@ class CtfTeamServiceTest extends CtfSpringTestHelper {
     String testFlag = "testFlag";
     Long testScore = 1234L;
 
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(SYSTEM.getId())
+        .name(SYSTEM.getName())
+        .build()));
+
     CtfChallengeAdminDto createChallengeInfo = CtfChallengeAdminDto.builder()
         .content(testContent)
         .contestId(contest.getId())
         .flag(testFlag)
         .isSolvable(true)
         .type(CtfChallengeTypeDto.builder().id(STANDARD.getId()).build())
-        .category(
-            CtfChallengeCategoryDto.builder().id(SYSTEM.getId()).build())
+        .category(category)
         .title(testTitle)
         .score(testScore)
         .maxSubmitCount(123L)

--- a/src/test/java/keeper/project/homepage/util/service/CtfUtilServiceTest.java
+++ b/src/test/java/keeper/project/homepage/util/service/CtfUtilServiceTest.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
+import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -55,8 +57,13 @@ class CtfUtilServiceTest extends CtfSpringTestHelper {
         validTeamList.add(generateCtfTeam(validCtf, generateMemberEntity(회원, 정회원, 일반회원), 0L)));
 
     validChallengeList = new ArrayList<>();
+    List<CtfChallengeCategoryDto> category = new ArrayList<>();
+    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
+        .id(FORENSIC.getId())
+        .name(FORENSIC.getName())
+        .build()));
     IntStream.range(0, VALID_CHALLENGE_COUNT).forEach(n -> {
-      CtfChallengeEntity challenge = generateCtfChallenge(validCtf, DYNAMIC, FORENSIC, 0L, true);
+      CtfChallengeEntity challenge = generateCtfChallenge(validCtf, DYNAMIC, category, 0L, true);
       generateDynamicChallengeInfo(challenge, 1000L, 100L);
       validChallengeList.add(challenge);
     });

--- a/src/test/java/keeper/project/homepage/util/service/CtfUtilServiceTest.java
+++ b/src/test/java/keeper/project/homepage/util/service/CtfUtilServiceTest.java
@@ -12,6 +12,7 @@ import java.util.stream.IntStream;
 import keeper.project.homepage.ctf.controller.CtfSpringTestHelper;
 import keeper.project.homepage.ctf.dto.CtfChallengeCategoryDto;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
+import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
 import keeper.project.homepage.ctf.entity.CtfFlagEntity;
@@ -57,13 +58,10 @@ class CtfUtilServiceTest extends CtfSpringTestHelper {
         validTeamList.add(generateCtfTeam(validCtf, generateMemberEntity(회원, 정회원, 일반회원), 0L)));
 
     validChallengeList = new ArrayList<>();
-    List<CtfChallengeCategoryDto> category = new ArrayList<>();
-    category.add(CtfChallengeCategoryDto.toDto(CtfChallengeCategoryEntity.builder()
-        .id(FORENSIC.getId())
-        .name(FORENSIC.getName())
-        .build()));
+    List<CtfChallengeCategory> categories = new ArrayList<>();
+    categories.add(FORENSIC);
     IntStream.range(0, VALID_CHALLENGE_COUNT).forEach(n -> {
-      CtfChallengeEntity challenge = generateCtfChallenge(validCtf, DYNAMIC, category, 0L, true);
+      CtfChallengeEntity challenge = generateCtfChallenge(validCtf, DYNAMIC, categories, 0L, true);
       generateDynamicChallengeInfo(challenge, 1000L, 100L);
       validChallengeList.add(challenge);
     });


### PR DESCRIPTION
## 연관 issue

close : #471

- #471

## 프론트 전달사항

[ctfAdmin.pdf](https://github.com/KEEPER31337/Homepage-Back/files/10287459/ctfAdmin.pdf)
- CTF 문제 생성
- CTF 문제 오픈
- CTF 문제 닫기
- CTF 문제 삭제
- CTF ADMIN 문제 목록 불러오기

[ctfChallenge.pdf](https://github.com/KEEPER31337/Homepage-Back/files/10287461/ctfChallenge.pdf)

- CTF 문제 목록 조회
- CTF 문제 세부 정보 조회

[ctfTeam.pdf](https://github.com/KEEPER31337/Homepage-Back/files/10287462/ctfTeam.pdf)

- 팀 세부 정보 열람

위 API 문서들은 업데이트 되었습니다!
<hr>

코드 리뷰 해주시면 감사합니다. 🙇‍♀️

