### PR TITLE
fix: DB의 저장 범위와 LocalDateTime 자료형의 저장 범위가 달라 String이 일치하지 않았던 문제 해결

### DIFF
--- a/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
+++ b/src/main/java/keeper/project/homepage/ctf/dto/CtfCommonChallengeDto.java
@@ -2,6 +2,7 @@ package keeper.project.homepage.ctf.dto;
 
 import static java.util.stream.Collectors.toList;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -41,7 +42,9 @@ public class CtfCommonChallengeDto {
   @JsonProperty(access = Access.READ_ONLY)
   private Long remainedSubmitCount;
   @JsonProperty(access = Access.READ_ONLY)
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
   private LocalDateTime lastTryTime;
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
   @JsonProperty(access = Access.READ_ONLY)
   private LocalDateTime solvedTime;
   @JsonProperty(access = Access.READ_ONLY)

--- a/src/test/java/keeper/project/homepage/ctf/controller/CtfChallengeControllerTest.java
+++ b/src/test/java/keeper/project/homepage/ctf/controller/CtfChallengeControllerTest.java
@@ -2,7 +2,6 @@ package keeper.project.homepage.ctf.controller;
 
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.FORENSIC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.MISC;
-import static keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory.WEB;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.DYNAMIC;
 import static keeper.project.homepage.ctf.entity.CtfChallengeTypeEntity.CtfChallengeType.STANDARD;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -19,9 +18,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity;
 import keeper.project.homepage.ctf.entity.CtfChallengeCategoryEntity.CtfChallengeCategory;
 import keeper.project.homepage.ctf.entity.CtfChallengeEntity;
 import keeper.project.homepage.ctf.entity.CtfContestEntity;
@@ -144,7 +143,8 @@ class CtfChallengeControllerTest extends CtfSpringTestHelper {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.code").value(0))
         .andExpect(jsonPath("$.list[0].lastTryTime").isEmpty())
-        .andExpect(jsonPath("$.list[1].lastTryTime").value(lastTryTime.toString()));
+        .andExpect(jsonPath("$.list[1].lastTryTime").value(
+            lastTryTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))));
   }
 
   @Test


### PR DESCRIPTION
## 연관 issue

없음.

## 프론트 전달사항

없음.

DB `DATETIME` 컬럼의 저장 범위와 `LocalDateTime` 자료형의 저장 범위가 달라 `String`이 일치하지 않아 테스트가 실패하던 문제를 해결했습니다.

기존: `"lastTryTime":"2023-01-09T20:02:07.1234567891"`
이 경우 `ns`까지 읽게 되면서 굉장히 길어질 수 있습니다.
하지만 DB는 저 만큼의 `ns`를 저장하지 않기 때문에 중간에 잘리게 됩니다.

그래서 타임 포맷을 `yyyy-MM-ddTHH:mm:ss`로 맞추고 `ms` 단위는 클라이언트에게 전파하지 않았습니다.